### PR TITLE
Hack6

### DIFF
--- a/hls-writer/hls_model.py
+++ b/hls-writer/hls_model.py
@@ -553,7 +553,8 @@ class BinaryDense(Dense):
         self.add_output_variable(shape, dims)
         self.add_weights_variable(name='weight', var_name='w{index}', data='kernel', type_name='weights{index}_t', precision='ap_uint<1>', quantize=quantize)
         self.weights['weight'].nzeros = 0
-        self.weights['weight'].data = np.transpose(self.weights['weight'].data)
+        if self.model.config.get_strategy(self) == 'Resource':
+            self.weights['weight'].data = np.transpose(self.weights['weight'].data)
         # binary layer has no bias, so initialize a 0 array
         zeros = np.zeros(shape=(self.attributes['n_out']))
         self.add_weights_variable(name='bias', var_name='b{index}', data=zeros, type_name='bias{index}_t', precision='ap_uint<1>', quantize=quantize)

--- a/hls-writer/optimizer/passes/bnbinary.py
+++ b/hls-writer/optimizer/passes/bnbinary.py
@@ -1,5 +1,6 @@
 import numpy as np
 import sys
+import re
 
 sys.path.insert(0, '../')
 from optimizer import OptimizerPass
@@ -18,7 +19,15 @@ class BatchNormalizationBinaryTanh(hls_model.Layer):
         shape = inp.shape
         dims = inp.dim_names
         self.add_output_variable(shape, dims, precision='ap_uint<1>')
-
+        precision_bits = re.search('.+<(.+?)>', inp.precision).group(1).split(',')
+        if 'ap_int' in inp.precision:
+          W = int(precision_bits[0])
+          I = W
+          F = 0
+        elif 'ap_fixed' in inp.precision:
+          W = int(precision_bits[0])
+          I = int(precision_bits[1])
+          F = W - I
         original_name = self.attributes.get('original_name')
         variance = self.model.get_weights_data(original_name, 'moving_variance')
         mean = self.model.get_weights_data(original_name, 'moving_mean')
@@ -26,6 +35,7 @@ class BatchNormalizationBinaryTanh(hls_model.Layer):
         beta = self.model.get_weights_data(original_name, 'beta')
         epsilon = self.attributes.get('epsilon')
         threshold = mean - beta * np.sqrt(variance + epsilon) / gamma
+        threshold = np.floor(threshold * 2**F) / 2**F
         self.add_weights_variable(name='threshold', data=threshold, type_name='threshold{index}_t', precision=inp.precision)
 
     def function_cpp(self):
@@ -99,11 +109,22 @@ class QuantizeBinaryDenseOutput(OptimizerPass):
         out_var.precision = out_type
         node.precision[out_var.type] = out_type
         # If followed by the BatchNormalizationBinaryTanh, update its input
+        # Also requantise the weights based on the input type
         bd_out_nodes = node.get_output_nodes()
         for out_node in bd_out_nodes:
             if out_node.__class__.__name__ == 'BatchNormalizationBinaryTanh':
                 threshold_var = out_node.weights['threshold']
                 threshold_var.precision = out_type
+                precision_bits = re.search('.+<(.+?)>', out_type).group(1).split(',')
+                if 'ap_int' in out_type:
+                  W = int(precision_bits[0])
+                  I = W
+                  F = 0
+                elif 'ap_fixed' in out_type:
+                  W = int(precision_bits[0])
+                  I = int(precision_bits[1])
+                  F = W - I
+                threshold_var.data = np.floor(threshold_var.data * 2**F) / 2**F
                 out_node.precision[threshold_var.type] = out_type
 
         return False

--- a/keras-to-hls/quickstart.py
+++ b/keras-to-hls/quickstart.py
@@ -21,7 +21,7 @@ get_custom_objects().update({"ZeroSomeWeights": ZeroSomeWeights})
 import yaml
 #from train import parse_config, get_features
 from quantized_layers import Clip, BinaryDense, TernaryDense, QuantizedDense
-from models import binary_tanh, ternary_tanh, quantized_relu
+from models import binary_tanh, ternary_tanh, quantized_relu, relu1
 
 json_file = open(yamlConfig['KerasJson'], 'r')
 loaded_model_json = json_file.read()
@@ -30,6 +30,7 @@ model = keras.models.model_from_json(loaded_model_json, custom_objects={'ZeroSom
                                                            'BinaryDense': BinaryDense,
                                                            'binary_tanh': binary_tanh,
                                                            'quantized_relu': quantized_relu,
+                                                           'relu1' : relu1,
                                                            'Clip': Clip})
 model.load_weights(yamlConfig['KerasH5'])
 
@@ -46,5 +47,5 @@ def model_up_to(model, n):
     m.add(layer)
   return m
 
-for n in range(0, len(model.layers)):
-  print(n, model_up_to(model, n).predict(x))
+#for n in range(0, len(model.layers)):
+#  print(n, model_up_to(model, n).predict(x))

--- a/nnet_utils/nnet_batchnorm.h
+++ b/nnet_utils/nnet_batchnorm.h
@@ -122,7 +122,7 @@ void  normalize_binary_tanh(data_T data[CONFIG_T::n_in], ap_uint<1> res[CONFIG_T
             #pragma HLS PIPELINE
         }
         datareg = data[ii];	 
-        if( datareg >= threshold[ii] ) cache = 1;
+        if( datareg > threshold[ii] ) cache = 1;
         else cache = 0;
 
         res[ii] = (ap_uint<1>) cache;


### PR DESCRIPTION
Add weight (threshold) quantisation to merge batch norm + binary tanh layer.
The thresholds are quantised after the layer input type is set during the optimisation pass.
Thresholds are rounded towards -ve infinity, and the comparison in the nnet_utils changed from '>=' to '>' to behave appropriately.
Also fix weight transpose for BinaryDense.