### PR TITLE
Add a bit to the dense layer output

### DIFF
--- a/nnet_utils/nnet_dense.h
+++ b/nnet_utils/nnet_dense.h
@@ -81,9 +81,9 @@ product(data_T a, weight_T w){
 
 template<class data_T, class res_T, typename CONFIG_T>
 inline typename std::enable_if<std::is_same<data_T, ap_uint<1>>::value
-        and std::is_same<typename CONFIG_T::weight_t, ap_uint<1>>::value, ap_int<nnet::ceillog2(CONFIG_T::n_in) + 1>>::type
+        and std::is_same<typename CONFIG_T::weight_t, ap_uint<1>>::value, ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2>>::type
 cast(typename CONFIG_T::accum_t x){
-  return (ap_int<nnet::ceillog2(CONFIG_T::n_in) + 1>) (x - CONFIG_T::n_in / 2) * 2;
+  return (ap_int<nnet::ceillog2(CONFIG_T::n_in) + 2>) (x - CONFIG_T::n_in / 2) * 2;
 }
 
 template<class data_T, class res_T, typename CONFIG_T>


### PR DESCRIPTION
Prevent overflow problem with Binary Dense output by adding 1 bit to output type.
HLS CSIM and Keras now agree over large dataset.