### PR TITLE
add script for vivado synthesis

### DIFF
--- a/hls-template/script.tcl
+++ b/hls-template/script.tcl
@@ -1,0 +1,3 @@
+add_files myproject_prj/solution1/syn/vhdl
+synth_design -top myproject -part xcku115-flvb2104-2-i
+report_utilization -file util.rpt

--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -336,7 +336,22 @@ def write_build_script(model):
         fout.write(line)
     f.close()
     fout.close()
+    
+    f = open(os.path.join(filedir,'../hls-template/script.tcl'),'r')
+    fout = open('{}/script.tcl'.format(model.config.get_output_dir()),'w')    
+    for line in f.readlines():
 
+        line = line.replace('myproject',model.config.get_project_name())
+	
+        if '-part' in line:
+         line = 'synth_design -top {} -part {}\n'.format(model.config.get_project_name(),model.config.get_config_value('XilinxPart'))
+	
+        fout.write(line)
+    f.close()
+    fout.close()	 
+	
+	
+	
 def write_tar(model):
     ###################
     # Tarball output


### PR DESCRIPTION
Add script for Vivado synthesis from @thesps and changed hls-writer to modify the template to follow user configuration. This would make the Vivado synthesis part of the workflow. Indeed, we are seeing large differences in LUTs wrt HLS for the binary/ternary nets.