### PR TITLE
manually rebased garnet-devel on hack7

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -19,6 +19,9 @@ class KerasDataReader:
                 return name
 
         with h5py.File(self.config['KerasH5'], 'r') as h5file:
+            if 'model_weights' in h5file:
+                h5file = h5file['model_weights']
+
             found_data = h5file[layer_name].visit(h5_visitor_func)
             if found_data:
                 data = h5file[layer_name][found_data][()]
@@ -33,6 +36,9 @@ def get_weights_shape(h5filename, layer_name, var_name='kernel'):
             return name
 
     with h5py.File(h5filename, 'r') as h5file:
+        if 'model_weights' in h5file:
+            h5file = h5file['model_weights']
+
         found_data = h5file[layer_name].visit(h5_visitor_func)
         if found_data:
             shape = h5file[layer_name][found_data].shape
@@ -60,10 +66,11 @@ def keras_to_hls(yamlConfig):
     norm_layers = ['BatchNormalization']
     activation_layers = ['Activation', 'LeakyReLU', 'ThresholdedReLU', 'ELU', 'PReLU']
     merge_layers = ['Add', 'Subtract', 'Multiply', 'Average', 'Maximum', 'Minimum', 'Concatenate']
+    graph_layers = ['GarNet']
     #Define layers to skip for conversion to HLS
     skip_layers = ['Dropout', 'Flatten']
     #All supported layers
-    supported_layers = core_layers + conv_layers + pooling_layers + norm_layers + activation_layers + merge_layers + skip_layers
+    supported_layers = core_layers + conv_layers + pooling_layers + norm_layers + activation_layers + merge_layers + graph_layers + skip_layers
 
     #Map inputs of skipped and split (activation) layers
     inputs_map = {}
@@ -98,13 +105,17 @@ def keras_to_hls(yamlConfig):
     for keras_layer in layer_config:
         if keras_layer["class_name"] not in supported_layers:
             raise Exception('ERROR: Unsupported layer type: {}'.format(keras_layer["class_name"]))
-        if 'batch_input_shape' in keras_layer['config']:
-            current_shape = keras_layer['config']['batch_input_shape'] # [None, 100, 7]
+
+    output_shapes = {}
+    output_shape = None
 
     print('Topology:')
     for keras_layer in layer_config:
-        if keras_layer["class_name"] == 'Flatten':
-            current_shape = [current_shape[0], np.prod(current_shape[1:])]
+        if 'batch_input_shape' in keras_layer['config']:
+            input_shapes = [keras_layer['config']['batch_input_shape']] # [None, 100, 7]
+        else:
+            input_shapes = [output_shapes[inbound_node[0][0]] for inbound_node in keras_layer['inbound_nodes']]
+        
         if keras_layer["class_name"] in skip_layers:
             if 'inbound_nodes' in keras_layer:
                 name = keras_layer['config']['name']
@@ -112,6 +123,12 @@ def keras_to_hls(yamlConfig):
                 parent_input = keras_layer['inbound_nodes'][0][0][0]
                 #Skipped layers can follow each other (e.g., Dropout -> Flatten)
                 inputs_map[name] = inputs_map.get(parent_input, parent_input)
+
+            if keras_layer["class_name"] == 'Flatten':
+                output_shapes[keras_layer['name']] = [input_shapes[0][0], np.prod(input_shapes[0][1:])]
+            else:
+                output_shapes[keras_layer['name']] = input_shapes[0]
+                
             continue
 
         if keras_layer["class_name"] in supported_layers:
@@ -140,10 +157,14 @@ def keras_to_hls(yamlConfig):
         # Default one layer call
         if layer['class_name'] == 'InputLayer':
             layer['input_shape'] = keras_layer['config']['batch_input_shape'][1:]
-        if keras_layer["class_name"] == 'Reshape':
+            if keras_layer['config']['dtype'] == 'int32':
+                layer['type_name'] = 'integer_input_t'
+                layer['precision'] = 'ap_int<32>'
+            output_shape = keras_layer['config']['batch_input_shape'] # [None, 100, 7]
+        elif keras_layer["class_name"] == 'Reshape':
             layer['target_shape'] = keras_layer['config']['target_shape']
-            current_shape[1:] = keras_layer['config']['target_shape']
-        if 'Dense' in layer['class_name']:
+            output_shape = input_shapes[0][:1] + keras_layer['config']['target_shape']
+        elif 'Dense' in layer['class_name']:
             weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
             layer['n_in'] = weights_shape[0]
             layer['n_out'] = weights_shape[1]
@@ -153,18 +174,18 @@ def keras_to_hls(yamlConfig):
                 layer['quantize'] = 3
             else:
                 layer['quantize'] = 0
-            current_shape = [current_shape[0], layer['n_out']]
+            output_shape = [input_shapes[0][0], layer['n_out']]
         elif layer['class_name']=='Conv1D':
             # weights_shape = (filter_width, n_channels, n_filters)
             weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
-            layer['n_in']=current_shape[1]
+            layer['n_in']=input_shapes[0][1]
             layer['filt_width']=weights_shape[0] # or keras_layer['config']['kernel_size']
             layer['n_chan']=weights_shape[1]
             layer['n_filt']=weights_shape[2] # or keras_layer['config']['filters']
             layer['stride']=keras_layer['config']['strides'][0]
             layer['padding']=keras_layer['config']['padding']
             if layer['padding']=='same':
-                in_width = current_shape[1]
+                in_width = input_shapes[0][1]
                 layer['n_out'] = int(math.ceil(float(in_width) / float(layer['stride'])))
                 if (in_width % layer['stride'] == 0):
                     pad_along_width = max(layer['filt_width'] - layer['stride'], 0)
@@ -173,21 +194,21 @@ def keras_to_hls(yamlConfig):
                 layer['pad_left']  = pad_along_width // 2
                 layer['pad_right']  = pad_along_width - layer['pad_left']
             elif layer['padding']=='valid':
-                in_width = current_shape[1]
+                in_width = input_shapes[0][1]
                 layer['n_out'] = int(math.ceil(float(in_width - layer['filt_width'] + 1) / float(layer['stride'])))
                 layer['pad_left'] = 0
                 layer['pad_right'] = 0
             layer['data_format'] = keras_layer['config'].get('data_format', 'channels_last')
-            current_shape=[current_shape[0], layer['n_out'], layer['n_filt']]
+            output_shape=[input_shapes[0][0], layer['y_out'], layer['n_filt']]
         elif 'Conv2D' in layer['class_name']:
             layer['data_format'] = keras_layer['config'].get('data_format', 'channels_last')
             # weights_shape = (filter_height, filter_width, n_channels, n_filters)
             weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
-            layer['in_height']=current_shape[1]
-            layer['in_width']=current_shape[2]
+            layer['in_height']=input_shapes[0][1]
+            layer['in_width']=input_shapes[0][2]
             if layer['data_format'] == 'channels_first':
-             layer['in_height']=current_shape[2]
-             layer['in_width']=current_shape[3]
+             layer['in_height']=input_shapes[0][2]
+             layer['in_width']=input_shapes[0][3]
             layer['filt_height']=weights_shape[0]
             layer['filt_width']=weights_shape[1]
             layer['n_chan']=weights_shape[2]
@@ -197,8 +218,8 @@ def keras_to_hls(yamlConfig):
             layer['padding']=keras_layer['config']['padding']
             if layer['padding']=='same':
                 #Height
-                in_height = current_shape[1]
-                if layer['data_format'] == 'channels_first': in_height = current_shape[2]
+                in_height = input_shapes[0][1]
+                if layer['data_format'] == 'channels_first': in_height = input_shapes[0][2]
                 layer['out_height'] = int(math.ceil(float(in_height) / float(layer['stride_height'])))
                 if (in_height % layer['stride_height'] == 0):
                     pad_along_height = max(layer['filt_height'] - layer['stride_height'], 0)
@@ -207,8 +228,8 @@ def keras_to_hls(yamlConfig):
                 layer['pad_top']  = pad_along_height // 2
                 layer['pad_bottom']  = pad_along_height - layer['pad_top']
                 #Width
-                in_width = current_shape[2]
-                if layer['data_format'] == 'channels_first': in_width = current_shape[3]
+                in_width = input_shapes[0][2]
+                if layer['data_format'] == 'channels_first': in_width = input_shapes[0][3]
                 layer['out_width'] = int(math.ceil(float(in_width) / float(layer['stride_width'])))
                 if (in_width % layer['stride_width'] == 0):
                     pad_along_width = max(layer['filt_width'] - layer['stride_width'], 0)
@@ -217,40 +238,40 @@ def keras_to_hls(yamlConfig):
                 layer['pad_left']  = pad_along_width // 2
                 layer['pad_right']  = pad_along_width - layer['pad_left']
             elif layer['padding']=='valid':
-                in_height = current_shape[1]
-                in_width = current_shape[2]
+                in_height = input_shapes[0][1]
+                in_width = input_shapes[0][2]
                 if layer['data_format'] == 'channels_first':
-                 in_height = current_shape[2]
-                 in_width = current_shape[3]
+                 in_height = input_shapes[0][2]
+                 in_width = input_shapes[0][3]
                 layer['out_width'] = int(math.ceil(float(in_width - layer['filt_width'] + 1) / float(layer['stride_width'])))
                 layer['out_height'] = int(math.ceil(float(in_height - layer['filt_height'] + 1) / float(layer['stride_height'])))
                 layer['pad_top'] = 0
                 layer['pad_bottom'] = 0
                 layer['pad_left'] = 0
                 layer['pad_right'] = 0
-            if layer['data_format'] == 'channels_first': current_shape=[current_shape[0], layer['n_filt'], layer['out_height'], layer['out_width']]
-            else: current_shape=[current_shape[0], layer['out_height'], layer['out_width'], layer['n_filt']]
+            if layer['data_format'] == 'channels_first': output_shape=[input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
+            else: output_shape=[input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_filt']]
         elif layer['class_name']=='BatchNormalization':
             in_size = 1
-            for dim in current_shape[1:]:
+            for dim in input_shapes[0][1:]:
                 in_size *= dim
             layer['n_in'] = in_size
             layer['n_out'] = layer['n_in']
-            if len(current_shape) == 2:
+            if len(input_shapes[0]) == 2:
                 layer['n_filt'] = -1
-            elif len(current_shape) == 3:
-                layer['n_filt']=current_shape[2]
-            elif len(current_shape) == 4:
-                layer['n_filt']=current_shape[3]
+            elif len(input_shapes[0]) == 3:
+                layer['n_filt']=input_shapes[0][2]
+            elif len(input_shapes[0]) == 4:
+                layer['n_filt']=input_shapes[0][3]
         elif 'Pooling' in layer['class_name']:
             if int(layer['class_name'][-2]) == 1:
-                layer['n_in']=current_shape[1]
-                layer['n_filt']=current_shape[2]
+                layer['n_in']=input_shapes[0][1]
+                layer['n_filt']=input_shapes[0][2]
                 layer['pool_size']=keras_layer['config']['pool_size'][0]
                 layer['stride']=keras_layer['config']['strides'][0]
                 layer['padding']=keras_layer['config']['padding']
                 if layer['padding']=='same':
-                    in_width = current_shape[1]
+                    in_width = input_shapes[0][1]
                     layer['n_out'] = int(math.ceil(float(in_width) / float(layer['stride'])))
                     if (in_width % layer['stride'] == 0):
                         pad_along_width = max(layer['pool_size'] - layer['stride'], 0)
@@ -259,20 +280,20 @@ def keras_to_hls(yamlConfig):
                     layer['pad_left']  = pad_along_width // 2
                     layer['pad_right']  = pad_along_width - layer['pad_left']
                 elif layer['padding']=='valid':
-                    in_width = current_shape[1]
+                    in_width = input_shapes[0][1]
                     layer['n_out'] = int(math.ceil(float(in_width - layer['pool_size'] + 1) / float(layer['stride'])))
                     layer['pad_left'] = 0
                     layer['pad_right'] = 0
-                current_shape=[current_shape[0], layer['n_out'], layer['n_filt']]
+                output_shape=[input_shapes[0][0], layer['n_out'], layer['n_filt']]
             elif int(layer['class_name'][-2]) == 2:
                 layer['data_format'] = keras_layer['config'].get('data_format', 'channels_last')
-                layer['in_height']=current_shape[1]
-                layer['in_width']=current_shape[2]
-                layer['n_filt']=current_shape[3]
+                layer['in_height']=input_shapes[0][1]
+                layer['in_width']=input_shapes[0][2]
+                layer['n_filt']=input_shapes[0][3]
                 if layer['data_format'] == 'channels_first':
-                 layer['in_height']=current_shape[2]
-                 layer['in_width']=current_shape[3]
-                 layer['n_filt']=current_shape[1]
+                 layer['in_height']=input_shapes[0][2]
+                 layer['in_width']=input_shapes[0][3]
+                 layer['n_filt']=input_shapes[0][1]
                 layer['stride_height']=keras_layer['config']['strides'][0]
                 layer['stride_width']=keras_layer['config']['strides'][1]
                 layer['pool_height']=keras_layer['config']['pool_size'][0]
@@ -280,8 +301,8 @@ def keras_to_hls(yamlConfig):
                 layer['padding']=keras_layer['config']['padding']
                 if layer['padding']=='same':
                     #Height
-                    in_height = current_shape[1]
-                    if layer['data_format'] == 'channels_first': in_height = current_shape[2]
+                    in_height = input_shapes[0][1]
+                    if layer['data_format'] == 'channels_first': in_height = input_shapes[0][2]
                     layer['out_height'] = int(math.ceil(float(in_height) / float(layer['stride_height'])))
                     if (in_height % layer['stride_height'] == 0):
                         pad_along_height = max(layer['pool_height'] - layer['stride_height'], 0)
@@ -290,8 +311,8 @@ def keras_to_hls(yamlConfig):
                     layer['pad_top']  = pad_along_height // 2
                     layer['pad_bottom']  = pad_along_height - layer['pad_top']
                     #Width
-                    in_width = current_shape[2]
-                    if layer['data_format'] == 'channels_first': in_height = current_shape[3]
+                    in_width = input_shapes[0][2]
+                    if layer['data_format'] == 'channels_first': in_height = input_shapes[0][3]
                     layer['out_width'] = int(math.ceil(float(in_width) / float(layer['stride_width'])))
                     if (in_width % layer['stride_width'] == 0):
                         pad_along_width = max(layer['pool_width'] - layer['stride_width'], 0)
@@ -300,19 +321,19 @@ def keras_to_hls(yamlConfig):
                     layer['pad_left']  = pad_along_width // 2
                     layer['pad_right']  = pad_along_width - layer['pad_left']
                 elif layer['padding']=='valid':
-                    in_height = current_shape[1]
-                    in_width = current_shape[2]
+                    in_height = input_shapes[0][1]
+                    in_width = input_shapes[0][2]
                     if layer['data_format'] == 'channels_first':
-                     in_height = current_shape[2]
-                     in_width = current_shape[3]
+                     in_height = input_shapes[0][2]
+                     in_width = input_shapes[0][3]
                     layer['out_width'] = int(math.ceil(float(in_width - layer['pool_width'] + 1) / float(layer['stride_width'])))
                     layer['out_height'] = int(math.ceil(float(in_height - layer['pool_height'] + 1) / float(layer['stride_height'])))
                     layer['pad_top'] = 0
                     layer['pad_bottom'] = 0
                     layer['pad_left'] = 0
                     layer['pad_right'] = 0
-                if layer['data_format'] == 'channels_last': current_shape=[current_shape[0], layer['out_height'], layer['out_width'], layer['n_filt']]
-                elif layer['data_format'] == 'channels_first': current_shape=[current_shape[0], layer['n_filt'], layer['out_height'], layer['out_width']]
+                if layer['data_format'] == 'channels_last': output_shape=[input_shapes[0][0], layer['out_height'], layer['out_width'], layer['n_filt']]
+                elif layer['data_format'] == 'channels_first': output_shape=[input_shapes[0][0], layer['n_filt'], layer['out_height'], layer['out_width']]
 
         elif layer['class_name']=='LeakyReLU':
             layer['activation'] = layer['class_name']
@@ -329,7 +350,7 @@ def keras_to_hls(yamlConfig):
         elif layer['class_name'] in merge_layers:
             layer['op'] = layer['class_name'].lower()
             if layer['class_name'] == 'Concatenate':
-                rank = len(current_shape[1:])
+                rank = len(input_shapes[0][1:])
                 if rank > 3:
                     raise Exception('ERROR: Concatenation of tensors with rank > 3 is not yet supported.')
                 layer['op'] = layer['class_name'].lower() + '{}d'.format(rank)
@@ -339,7 +360,25 @@ def keras_to_hls(yamlConfig):
             if len(layer['inputs']) > 2:
                 raise Exception('ERROR: Merging more than two tensors is not yet supported.')
 
-        print('Layer name: {}, layer type: {}, current shape: {}'.format(layer['name'], layer['class_name'], current_shape))
+        elif layer['class_name'] == 'GarNet':
+            layer['n_vertices'] = input_shapes[0][1]
+            layer['n_in_features'] = input_shapes[0][2]
+            if keras_layer['config']['deduce_nvert']:
+                raise NotImplementedError('Cannot use GarNet with deduce_nvert=True')
+
+            layer['n_aggregators'] = keras_layer['config']['n_aggregators']
+            layer['n_filters'] = keras_layer['config']['n_filters'] # number of output features
+            layer['n_propagate'] = keras_layer['config']['n_propagate'] # number of latent features
+            layer['collapse'] = keras_layer['config']['collapse']
+
+            layer['vertex_unroll_factor'] = 4
+
+            if layer['collapse'] in ['mean', 'sum', 'max']:
+                output_shape = [input_shapes[0][0], layer['n_filters']]
+            else:
+                output_shape = input_shapes[0][:2] + [layer['n_filters']]
+
+        print('Layer name: {}, layer type: {}, current shape: {}'.format(layer['name'], layer['class_name'], input_shapes))
         layer_list.append( layer )
         if 'activation' in layer and layer['class_name'] not in activation_layers:
             act_layer = {}
@@ -355,6 +394,9 @@ def keras_to_hls(yamlConfig):
                 output_layers = [act_layer['name'] if name == layer['name'] else name for name in output_layers]
             layer_list.append(act_layer)
 
+        assert(output_shape is not None)
+        
+        output_shapes[keras_layer['name']] = output_shape
 
     #################
     ## Generate HLS

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -107,6 +107,8 @@ class HLSConfig(object):
         partitioning = self.layer_name_output_partitioning.get(layer.name.lower())
         if partitioning is None:
             partitioning = 'auto'
+        elif ',' in partitioning:
+            partitioning = tuple(partitioning.split(','))
 
         return partitioning
 
@@ -363,12 +365,18 @@ class ArrayVariable(Variable):
         self.shape = shape
         self.dim_names = dim_names
 
+        if type(pragma) is tuple:
+            args = pragma[1:]
+            pragma = pragma[0]
+        else:
+            args = tuple()
+
         if pragma == 'partition':
-            self.partition()
+            self.partition(*args)
         elif pragma == 'reshape':
-            self.reshape()
+            self.reshape(*args)
         elif pragma == 'stream':
-            self.stream()
+            self.stream(*args)
         else:
             self.pragma = None
 

--- a/hls4ml/model/templates.py
+++ b/hls4ml/model/templates.py
@@ -125,6 +125,29 @@ concat_config_template = """struct config{index} : nnet::concat_config {{
     static const unsigned axis = {axis};
 }};\n"""
 
+garnet_config_template = """struct config{index} : nnet::garnet_config {{
+    typedef {input_transform_weights_t} input_transform_weights_t;
+    typedef {input_transform_biases_t} input_transform_biases_t;
+    typedef {output_transform_weights_t} output_transform_weights_t;
+    typedef {output_transform_biases_t} output_transform_biases_t;
+    typedef {aggregator_distance_weights_t} aggregator_distance_weights_t;
+    typedef {aggregator_distance_biases_t} aggregator_distance_biases_t;
+
+    typedef {accum_t} accum_t;
+    typedef {edge_weight_t} edge_weight_t;
+    typedef {aggr_t} aggr_t;
+
+    static const unsigned n_vertices = {n_vertices};
+    static const unsigned n_in_features = {n_in_features};
+    static const unsigned n_aggregators = {n_aggregators};
+    static const unsigned n_filters = {n_filters};
+    static const unsigned n_propagate = {n_propagate};
+    static const unsigned distance_bitwidth = 10;
+
+    static const unsigned reuse_factor = {reuse};
+}};
+"""
+
 config_templates = {
     'Dense'                  : dense_config_template,
     'BinaryDense'            : dense_config_template,
@@ -138,6 +161,7 @@ config_templates = {
     'Pooling2D'              : pooling2d_config_template,
     'Merge'                  : merge_config_template,
     'Concatenate'            : concat_config_template,
+    'GarNet'                 : garnet_config_template
 }
 
 dense_function_template = 'nnet::dense_{strategy}<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
@@ -149,6 +173,7 @@ param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {conf
 pooling1d_function_template = 'nnet::pooling1d<{input_t}, {config}>({input}, {output});'
 pooling2d_function_template = 'nnet::pooling2d_{data_format}<{input_t}, {config}>({input}, {output});'
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'
+garnet_function_template = 'nnet::garnet<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output}, {input_transform_weights}, {input_transform_biases}, {aggregator_distance_weights}, {aggregator_distance_biases}, {output_transform_weights}, {output_transform_biases});'
 
 function_templates = {
     'Dense'                  : dense_function_template,
@@ -163,6 +188,7 @@ function_templates = {
     'Pooling2D'              : pooling2d_function_template,
     'Merge'                  : merge_function_template,
     'Concatenate'            : merge_function_template,
+    'GarNet'                 : garnet_function_template
 }
 
 def get_config_template(kind):

--- a/hls4ml/templates/vivado/firmware/parameters.h
+++ b/hls4ml/templates/vivado/firmware/parameters.h
@@ -11,6 +11,7 @@
 #include "nnet_utils/nnet_conv_large.h"
 #include "nnet_utils/nnet_conv2d.h"
 #include "nnet_utils/nnet_conv2d_large.h"
+#include "nnet_utils/nnet_garnet.h"
 #include "nnet_utils/nnet_activation.h"
 #include "nnet_utils/nnet_common.h"
 #include "nnet_utils/nnet_batchnorm.h"

--- a/hls4ml/templates/vivado/myproject_test.cpp
+++ b/hls4ml/templates/vivado/myproject_test.cpp
@@ -18,6 +18,7 @@
 //
 #include <fstream>
 #include <iostream>
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
@@ -126,7 +126,8 @@ compute_garnet_edge_weight(typename CONFIG_T::accum_t distance)
 
 #ifdef __SYNTHESIS__
   typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_bitwidth];
-  #pragma HLS ARRAY_RESHAPE variable=edge_weights_table complete dim=1
+  unsigned const reshape_factor = CONFIG_T::n_aggregators * CONFIG_T::n_in_features * (CONFIG_T::n_vertices / CONFIG_T::reuse_factor);
+  #pragma HLS ARRAY_RESHAPE variable=edge_weights_table cyclic factor=reshape_factor dim=1
   bool initialized = false;
 #else
   static typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_bitwidth];

--- a/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_garnet.h
@@ -1,0 +1,421 @@
+//
+//    rfnoc-hls-neuralnet: Vivado HLS code for neural-net building blocks
+//
+//    Copyright (C) 2017 EJ Kreinar
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef NNET_GARNET_H_
+#define NNET_GARNET_H_
+
+#define GARNET_COLLAPSE 1
+
+#include "nnet_common.h"
+#include "hls_stream.h"
+#include "hls_math.h"
+
+namespace nnet {
+
+template<class CONFIG_T>
+inline void
+edge_weight_sums_init(typename CONFIG_T::aggr_t edge_weight_sums[CONFIG_T::n_aggregators])
+{
+  #pragma HLS PIPELINE
+ EdgeWeightSumInit:
+  for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+    edge_weight_sums[ia] = 0.;
+  }
+}
+
+template<class CONFIG_T>
+inline void
+aggregation_sums_init(typename CONFIG_T::aggr_t aggregation_sums[CONFIG_T::n_aggregators * CONFIG_T::n_propagate])
+{
+  #pragma HLS PIPELINE
+ AggregationInit:
+  for (unsigned il = 0; il < CONFIG_T::n_aggregators * CONFIG_T::n_propagate; ++il) {
+    aggregation_sums[il] = 0.;
+  }
+}
+
+template<class CONFIG_T>
+inline typename std::enable_if<std::is_class<typename CONFIG_T::accum_t>::value>::type
+initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+  typedef ap_uint<CONFIG_T::distance_bitwidth> index_t;
+  typedef ap_fixed<CONFIG_T::distance_bitwidth, CONFIG_T::distance_bitwidth / 2, AP_RND, AP_SAT> rdistance_t;
+
+  unsigned const table_size = (1 << CONFIG_T::distance_bitwidth);
+
+  index_t index;
+  rdistance_t rdist;
+  typename CONFIG_T::accum_t distance;
+  
+  for (unsigned iw = 0; iw < table_size; ++iw) {
+    index = iw;
+    rdist.range(CONFIG_T::distance_bitwidth - 1, 0) = index.range(CONFIG_T::distance_bitwidth - 1, 0);
+    distance = rdist;
+    edge_weights_table[iw] = hls::pow(2., -distance);
+  }
+}
+
+template<class CONFIG_T>
+inline typename std::enable_if<not std::is_class<typename CONFIG_T::accum_t>::value>::type
+initialize_edge_weights_table(typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+  unsigned const table_size = (1 << CONFIG_T::distance_bitwidth);
+  double const step = 64. / table_size;
+
+  typename CONFIG_T::accum_t v = -32.;
+  for (unsigned iw = 0; iw < table_size; ++iw) {
+    edge_weights_table[iw] = std::pow(2., -v);
+    v += step;
+  }
+}
+
+template<class CONFIG_T>
+inline typename std::enable_if<std::is_class<typename CONFIG_T::accum_t>::value, typename CONFIG_T::edge_weight_t>::type
+get_edge_weight(typename CONFIG_T::accum_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+  typedef ap_uint<CONFIG_T::distance_bitwidth> index_t;
+  typedef ap_fixed<CONFIG_T::distance_bitwidth, CONFIG_T::distance_bitwidth / 2, AP_RND, AP_SAT> rdistance_t;
+
+  index_t index;
+  rdistance_t rdist = distance;
+
+  index.range(CONFIG_T::distance_bitwidth - 1, 0) = rdist.range(CONFIG_T::distance_bitwidth - 1, 0);
+
+  return edge_weights_table[index];
+}
+
+template<class CONFIG_T>
+inline typename std::enable_if<not std::is_class<typename CONFIG_T::accum_t>::value, typename CONFIG_T::edge_weight_t>::type
+get_edge_weight(typename CONFIG_T::accum_t distance, typename CONFIG_T::edge_weight_t edge_weights_table[])
+{
+  unsigned const table_size = (1 << CONFIG_T::distance_bitwidth);
+  double const step = 64. / table_size;
+  
+  int index = (distance + 32.) / step;
+  if (index < 0)
+    index = 0;
+  else if (index >= table_size)
+    index = table_size - 1;
+
+  return edge_weights_table[index];
+}
+
+template<class CONFIG_T>
+inline typename CONFIG_T::edge_weight_t
+compute_garnet_edge_weight(typename CONFIG_T::accum_t distance)
+{
+  #pragma HLS PIPELINE
+  // typename CONFIG_T::edge_weight_t edge_weight = 1.;
+  // return edge_weight >> distance.to_int();
+
+#ifdef __SYNTHESIS__
+  typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_bitwidth];
+  #pragma HLS ARRAY_RESHAPE variable=edge_weights_table complete dim=1
+  bool initialized = false;
+#else
+  static typename CONFIG_T::edge_weight_t edge_weights_table[1 << CONFIG_T::distance_bitwidth];
+  static bool initialized = false;
+#endif
+  if (!initialized) {
+    initialize_edge_weights_table<CONFIG_T>(edge_weights_table);
+    initialized = true;
+  }
+
+  return get_edge_weight<CONFIG_T>(distance, edge_weights_table);
+}
+
+template<class data_T, class nvtx_T, class CONFIG_T>
+void
+compute_features_weights(
+  data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
+  nvtx_T nvtx,
+  typename CONFIG_T::input_transform_weights_t const input_transform_weights[CONFIG_T::n_in_features * CONFIG_T::n_propagate],
+  typename CONFIG_T::input_transform_biases_t const input_transform_biases[CONFIG_T::n_propagate],
+  typename CONFIG_T::aggregator_distance_weights_t const aggregator_distance_weights[CONFIG_T::n_in_features * CONFIG_T::n_aggregators],
+  typename CONFIG_T::aggregator_distance_biases_t const aggregator_distance_biases[CONFIG_T::n_aggregators],
+#ifdef GARNET_COLLAPSE
+  typename CONFIG_T::aggr_t edge_weight_sums[CONFIG_T::n_aggregators],
+#else
+  typename CONFIG_T::edge_weight_t edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators],
+#endif
+  typename CONFIG_T::aggr_t aggregation_sums[CONFIG_T::n_aggregators * CONFIG_T::n_propagate]
+)
+{
+  #pragma HLS EXPRESSION_BALANCE
+
+ VerticesCompute:
+  for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+    unsigned cycle_factor = CONFIG_T::n_vertices / CONFIG_T::reuse_factor;
+    #pragma HLS UNROLL factor=cycle_factor skip_exit_check
+    #pragma HLS PIPELINE
+    
+    if (iv >= nvtx)
+      break;
+    
+    typename CONFIG_T::index_t const data_offset = iv * CONFIG_T::n_in_features;
+    typename CONFIG_T::index_t const features_offset = iv * CONFIG_T::n_propagate;
+    typename CONFIG_T::index_t const weights_offset = iv * CONFIG_T::n_aggregators;
+
+    typename CONFIG_T::accum_t propagated_features[CONFIG_T::n_propagate];
+
+    // keras Dense applies weights as K.dot(inputs, kernel) -> kernel is channels first
+
+  Propagate:
+    for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+      propagated_features[ip] = input_transform_biases[ip];
+    PropagateMatMul:
+      for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+        typename CONFIG_T::index_t data_index = data_offset + ix;
+        typename CONFIG_T::index_t weight_index = ix * CONFIG_T::n_propagate + ip;
+        propagated_features[ip] += data[data_index] * input_transform_weights[weight_index];
+      }
+    }
+
+  Accum:
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+      typename CONFIG_T::accum_t distance = aggregator_distance_biases[ia];
+    AccumMatMul:
+      for (unsigned ix = 0; ix < CONFIG_T::n_in_features; ++ix) {
+        typename CONFIG_T::index_t data_index = data_offset + ix;
+        typename CONFIG_T::index_t weight_index = ix * CONFIG_T::n_aggregators + ia;
+        distance += data[data_index] * aggregator_distance_weights[weight_index];
+      }
+
+      typename CONFIG_T::edge_weight_t edge_weight = compute_garnet_edge_weight<CONFIG_T>(distance);
+#ifdef GARNET_COLLAPSE
+      edge_weight_sums[ia] += edge_weight;
+#else
+      edge_weights[weights_offset + ia] = edge_weight;
+#endif
+
+    AccumPropagate:
+      for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+        typename CONFIG_T::aggr_t cache = edge_weight * propagated_features[ip];
+        aggregation_sums[ia * CONFIG_T::n_propagate + ip] += cache;
+      }
+    }
+  }
+}
+
+#ifdef GARNET_COLLAPSE
+
+template<class res_T, class nvtx_T, class CONFIG_T>
+void
+set_output(
+  nvtx_T nvtx,
+  typename CONFIG_T::aggr_t const edge_weight_sums[CONFIG_T::n_aggregators],
+  typename CONFIG_T::aggr_t const aggregation_sums[CONFIG_T::n_aggregators * CONFIG_T::n_propagate],
+  typename CONFIG_T::output_transform_weights_t const output_transform_weights[CONFIG_T::n_aggregators * CONFIG_T::n_propagate * CONFIG_T::n_filters],
+  typename CONFIG_T::output_transform_biases_t const output_transform_biases[CONFIG_T::n_filters],
+  res_T res[CONFIG_T::n_filters]
+)
+{
+  #pragma HLS PIPELINE
+  #pragma HLS EXPRESSION_BALANCE
+
+  #if GARNET_COLLAPSE == 1
+  typename CONFIG_T::aggr_t const vnorm2 = 1. / CONFIG_T::n_vertices / CONFIG_T::n_vertices;
+  typename CONFIG_T::aggr_t const nvtx_vnorm = float(nvtx) / CONFIG_T::n_vertices;
+  #endif
+
+ Output:
+  for (int io = 0; io < CONFIG_T::n_filters; ++io) {
+    typename CONFIG_T::aggr_t aggr = 0.;
+
+  OutputAggr:
+    for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+    OutputProp:
+      for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+        typename CONFIG_T::index_t il = ia * CONFIG_T::n_propagate + ip;
+        typename CONFIG_T::index_t weight_index = il * CONFIG_T::n_filters + io;
+          
+        aggr += edge_weight_sums[ia] * aggregation_sums[il] * output_transform_weights[weight_index];
+      }
+    }
+
+    #if GARNET_COLLAPSE == 1
+    // mean
+    aggr *= vnorm2;
+    aggr += output_transform_biases[io] * nvtx_vnorm;
+    #elif GARNET_COLLAPSE == 2
+    // sum
+    aggr += output_transform_biases[io] * nvtx;
+    #endif
+
+    res[io] = aggr;
+
+    //std::cout << "res " << io << " = " << aggr << " -> " << res[io] << std::endl;
+  }
+}
+
+#else
+
+template<class res_T, class nvtx_T, class CONFIG_T>
+void
+set_output(
+  nvtx_T nvtx,
+  typename CONFIG_T::accum_t const edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators],
+  typename CONFIG_T::aggr_t const aggregation_sums[CONFIG_T::n_aggregators * CONFIG_T::n_propagate],
+  typename CONFIG_T::output_transform_weights_t const output_transform_weights[CONFIG_T::n_aggregators * CONFIG_T::n_propagate * CONFIG_T::n_filters],
+  typename CONFIG_T::output_transform_biases_t const output_transform_biases[CONFIG_T::n_filters],
+  res_T res[CONFIG_T::n_vertices * CONFIG_T::n_filters]
+)
+{ 
+  #pragma HLS PIPELINE
+  #pragma HLS EXPRESSION_BALANCE
+
+  typename CONFIG_T::aggr_t const vnorm = 1. / CONFIG_T::n_vertices;
+
+ AggrSumNormalize:
+  for (unsigned il = 0; il < n_latent; ++il) {
+    aggregation_sums[il] *= vnorm;
+  }
+
+ Output:
+  for (unsigned iv = 0; iv < CONFIG_T::n_vertices; ++iv) {
+    if (iv >= nvtx)
+      break;
+
+    typename CONFIG_T::index_t res_offset = iv * CONFIG_T::n_filters;
+    typename CONFIG_T::index_t edge_weight_offset = iv * CONFIG_T::n_aggregators;
+
+  OutputFilt:
+    for (unsigned io = 0; io < CONFIG_T::n_filters; ++io) {
+      typename CONFIG_T::aggr_t aggr = output_transform_biases[io];
+
+    OutputAggr:
+      for (unsigned ia = 0; ia < CONFIG_T::n_aggregators; ++ia) {
+        typename CONFIG_T::edge_weight_t edge_weight = edge_weights[edge_weight_offset + ia];
+
+      OutputProp:
+        for (unsigned ip = 0; ip < CONFIG_T::n_propagate; ++ip) {
+          typename CONFIG_T::index_t il = ia * CONFIG_T::n_propagate + ip;
+          typename CONFIG_T::index_t weight_index = il * CONFIG_T::n_filters + io;
+        
+          aggr += edge_weight * aggregation_sums[il] * output_transform_weights[weight_index];
+        }
+      }
+
+      res[res_offset + io] = aggr;
+    }
+  }
+}
+
+#endif
+
+struct garnet_config
+{
+  // Internal data type definitions
+  typedef float input_transform_weights_t;
+  typedef float input_transform_biases_t;
+  typedef float output_transform_weights_t;
+  typedef float output_transform_biases_t;
+  typedef float aggregator_distance_weights_t;
+  typedef float aggregator_distance_biases_t;
+
+  typedef float accum_t;
+  typedef ap_ufixed<64, 32> edge_weight_t;
+  typedef ap_fixed<64, 24> aggr_t;
+
+  typedef unsigned short index_t;
+
+  // Layer specs
+  static const unsigned n_vertices = 250;
+  static const unsigned n_in_features = 4;
+  static const unsigned n_aggregators = 4;
+  static const unsigned n_filters = 4;
+  static const unsigned n_propagate = 4;
+  static const unsigned distance_bitwidth = 10;
+
+  // Optimization specs
+  static const unsigned reuse_factor = 64;
+};
+
+template<class data_T, class nvtx_T, class res_T, typename CONFIG_T>
+void garnet(
+    data_T const data[CONFIG_T::n_vertices * CONFIG_T::n_in_features],
+    nvtx_T const nvtx[1],
+#ifdef GARNET_COLLAPSE
+    res_T res[CONFIG_T::n_filters],
+#else
+    res_T res[CONFIG_T::n_vertices * CONFIG_T::n_filters],
+#endif
+    typename CONFIG_T::input_transform_weights_t const input_transform_weights[CONFIG_T::n_in_features * CONFIG_T::n_propagate],
+    typename CONFIG_T::input_transform_biases_t const input_transform_biases[CONFIG_T::n_propagate],
+    typename CONFIG_T::aggregator_distance_weights_t const aggregator_distance_weights[CONFIG_T::n_in_features * CONFIG_T::n_aggregators],
+    typename CONFIG_T::aggregator_distance_biases_t const aggregator_distance_biases[CONFIG_T::n_aggregators],
+    typename CONFIG_T::output_transform_weights_t const output_transform_weights[CONFIG_T::n_aggregators * CONFIG_T::n_propagate * CONFIG_T::n_filters],
+    typename CONFIG_T::output_transform_biases_t const output_transform_biases[CONFIG_T::n_filters]
+)
+{
+  #pragma HLS DATAFLOW
+  
+  typename CONFIG_T::aggr_t aggregation_sums[CONFIG_T::n_aggregators * CONFIG_T::n_propagate];
+  #pragma HLS ARRAY_RESHAPE variable=aggregation_sums complete dim=1
+
+#ifdef GARNET_COLLAPSE
+  typename CONFIG_T::aggr_t edge_weight_sums[CONFIG_T::n_aggregators];
+  #pragma HLS ARRAY_RESHAPE variable=edge_weight_sums complete dim=1
+#else
+  typename CONFIG_T::edge_weight_t edge_weights[CONFIG_T::n_vertices * CONFIG_T::n_aggregators];
+  unsigned const reshape_factor = CONFIG_T::n_aggregators * (CONFIG_T::n_vertices / CONFIG_T::reuse_factor);
+  #pragma HLS ARRAY_RESHAPE variable=edge_weights cyclic factor=reshape_factor dim=1
+#endif
+
+  nvtx_T nvtx_local_1 = nvtx[0];
+  nvtx_T nvtx_local_2 = nvtx[0];
+
+  aggregation_sums_init<CONFIG_T>(aggregation_sums);
+
+#ifdef GARNET_COLLAPSE
+  edge_weight_sums_init<CONFIG_T>(edge_weight_sums);
+#endif
+  
+ compute_features_weights<data_T, nvtx_T, CONFIG_T>(
+    data,
+    nvtx_local_1,
+    input_transform_weights,
+    input_transform_biases,
+    aggregator_distance_weights,
+    aggregator_distance_biases,
+#ifdef GARNET_COLLAPSE
+    edge_weight_sums,
+#else
+    edge_weights,
+#endif
+    aggregation_sums
+  );
+
+  set_output<res_T, nvtx_T, CONFIG_T>(
+    nvtx_local_2,
+#ifdef GARNET_COLLAPSE
+    edge_weight_sums,
+#else
+    edge_weights,
+#endif
+    aggregation_sums,
+    output_transform_weights,
+    output_transform_biases,
+    res
+  );
+}
+
+}
+
+#endif

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -130,6 +130,29 @@ concat_config_template = """struct config{index} : nnet::concat_config {{
     static const unsigned axis = {axis};
 }};\n"""
 
+garnet_config_template = """struct config{index} : nnet::garnet_config {{
+    typedef {input_transform_weights_t} input_transform_weights_t;
+    typedef {input_transform_biases_t} input_transform_biases_t;
+    typedef {output_transform_weights_t} output_transform_weights_t;
+    typedef {output_transform_biases_t} output_transform_biases_t;
+    typedef {aggregator_distance_weights_t} aggregator_distance_weights_t;
+    typedef {aggregator_distance_biases_t} aggregator_distance_biases_t;
+
+    typedef {accum_t} accum_t;
+    typedef {edge_weight_t} edge_weight_t;
+    typedef {aggr_t} aggr_t;
+
+    static const unsigned n_vertices = {n_vertices};
+    static const unsigned n_in_features = {n_in_features};
+    static const unsigned n_aggregators = {n_aggregators};
+    static const unsigned n_filters = {n_filters};
+    static const unsigned n_propagate = {n_propagate};
+    static const unsigned distance_bitwidth = 10;
+
+    static const unsigned reuse_factor = {reuse};
+}};
+"""
+
 '''config_templates = {
     'Dense'                  : dense_config_template,
     'BinaryDense'            : dense_config_template,
@@ -154,6 +177,7 @@ param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {conf
 pooling1d_function_template = 'nnet::pooling1d<{input_t}, {config}>({input}, {output});'
 pooling2d_function_template = 'nnet::pooling2d_{data_format}<{input_t}, {config}>({input}, {output});'
 merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'
+garnet_function_template = 'nnet::garnet<{input_t}, {integer_input_t}, {output_t}, {config}>({input}, {nvtx}, {output}, {input_transform_weights}, {input_transform_biases}, {aggregator_distance_weights}, {aggregator_distance_biases}, {output_transform_weights}, {output_transform_biases});'
 
 '''function_templates = {
     'Dense'                  : dense_function_template,
@@ -185,6 +209,7 @@ class VivadoBackend(Backend):
         self.register_templates('Pooling2D'              , pooling2d_function_template,   pooling2d_config_template)
         self.register_templates('Merge'                  , merge_function_template,       merge_config_template)
         self.register_templates('Concatenate'            , merge_function_template,       concat_config_template)
+        self.register_templates('GarNet'                 , garnet_function_template,      garnet_config_template)
     
     def get_valid_reuse_factors(self, layer):
         n_in = 0

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -109,10 +109,12 @@ class VivadoWriter(Writer):
                 all_inputs = [i.cppname for i in model_inputs]
                 all_outputs = [o.cppname for o in model_outputs]
 
-                if model.config.get_config_value("CustomizeIO", False):
+                if model.config.get_config_value("CustomizeIO"):
                     for i in model_inputs: newline += indent + i.pragma + '\n'
                     for o in model_outputs: newline += indent + o.pragma + '\n'
-                    interface_mode = model.config.get_config_value('InterfaceMode', 'ap_vld')
+                    interface_mode = model.config.get_config_value('InterfaceMode')
+                    if interface_mode is None:
+                        interface_mode = 'ap_vld'
                     newline += indent + '#pragma HLS INTERFACE {} port={},{} \n'.format(interface_mode, ','.join(all_inputs), ','.join(all_outputs))
                 else:
                     if model.config.get_config_value("IOType") == "io_parallel":
@@ -122,7 +124,7 @@ class VivadoWriter(Writer):
                     elif model.config.get_config_value("IOType") == "io_serial":
                         newline += indent + '#pragma HLS INTERFACE axis port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
 
-                global_pipelining = model.config.get_config_value('GlobalPipelining', None)
+                global_pipelining = model.config.get_config_value('GlobalPipelining')
                 if global_pipelining:
                     if global_pipelining in ['PIPELINE', 'DATAFLOW']:
                         newline += indent + '#pragma HLS ' + global_pipelining + '\n'

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -124,7 +124,8 @@ class VivadoWriter(Writer):
 
                 global_pipelining = model.config.get_config_value('GlobalPipelining', None)
                 if global_pipelining:
-                    newline += indent + '#pragma HLS ' + global_pipelining + '\n'
+                    if global_pipelining in ['PIPELINE', 'DATAFLOW']:
+                        newline += indent + '#pragma HLS ' + global_pipelining + '\n'
                 else:
                     if model.config.get_config_value("IOType") == "io_parallel":
                         if model.config.model_strategy == 'Resource':


### PR DESCRIPTION
PR to discuss the changes I made to make GarNet work with HLS4ML.
Main points are:
- Because the array the layer deals with tends to be large, output array partitioning options that were available (complete reshape or complete partition) would make it unsynthesizable. Added an option to specify the output partitioning from the config in hls_model.py (get_output_partitioning and related code there)
- Loosened the assumption on the input type - input can be an integer, as in the number of vertices for each sample that we provide to GarNet.
- We needed support for multiple input / output arrays to / from the layers. In keras_to_hls.py, each layer registers the output shape to an output_shapes dict (used only internally) and reads the input shapes from the output_shapes of the previous layer. The variable current_shape (which was the mediator of the shape information) is not used any more.
- Added model config CustomizeIO and GlobalPipelining to control how input / output arrays should be partitioned and whether there should be PIPELINE, DATAFLOW, or neither at the top level. GarNet could not synthesize with PIPELINE at the top because of the large loop size.