### PR TITLE
Adding support for h5 file from model.save()

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -3,6 +3,7 @@ import numpy as np
 import h5py
 import json
 import math
+import keras
 
 from hls4ml.model import HLSModel
 from hls4ml.model.optimizer import optimize_model
@@ -67,10 +68,9 @@ def keras_to_hls(yamlConfig):
     layer_list = []
     
     #If the json file is not provided, interpret this as the full model is saved in KerasH5 with model.save()
-    if 'KerasJson' not in yamlConfig:
-        with open( yamlConfig['KerasH5'] ) as h5_file:
+    if  not yamlConfig['KerasJson']:
             #Load the model's info and add them in a dict
-            full_model =  keras.models.load_model(h5_file)
+            full_model =  keras.models.load_model(yamlConfig['KerasH5'])
             model_arch = {
                     "class_name": full_model.__class__.__name__,
                     "config": full_model.get_config()

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -69,7 +69,7 @@ def keras_to_hls(yamlConfig):
     #If the json file is not provided, interpret this as the full model is saved in KerasH5 with model.save()
     if  not yamlConfig['KerasJson']:
             #Load the model's info and add them in a dict
-            filepath = yamlConfig['KerasJson']
+            filepath = yamlConfig['KerasH5']
 
             #Open file
             opened_new_file = not isinstance(filepath, h5py.File)

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -47,10 +47,21 @@ def keras_to_hls(yamlConfig):
 
     #This is a list of dictionaries to hold all the layer info we need to generate HLS
     layer_list = []
-
-    #Extract model architecture from json
-    with open( yamlConfig['KerasJson'] ) as json_file:
-        model_arch = json.load(json_file)
+    
+    #If the json file is not provided, interpret this as the full model is saved in KerasH5 with model.save()
+    if 'KerasJson' not in yamlConfig:
+        with open( yamlConfig['KerasH5'] ) as h5_file:
+            #Load the model's info and add them in a dict
+            full_model =  keras.models.load_model(h5_file)
+            model_arch = {
+                    "class_name": full_model.__class__.__name__,
+                    "config": full_model.get_config()
+                    }
+    else:
+        #Extract model architecture from json
+        with open( yamlConfig['KerasJson'] ) as json_file:
+            model_arch = json.load(json_file)
+    
     #print(model_arch)
 
     #Define supported laers

--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -19,23 +19,41 @@ class KerasDataReader:
                 return name
 
         with h5py.File(self.config['KerasH5'], 'r') as h5file:
-            found_data = h5file[layer_name].visit(h5_visitor_func)
-            if found_data:
-                data = h5file[layer_name][found_data][()]
-            else:
-                data = None
+            #If the h5 file is the whole model saved with model.save()
+            if 'model_weights' in list(h5file.keys()):
+                found_data = h5file['model_weights/{}'.format(layer_name)].visit(h5_visitor_func)
+                if found_data:
+                    data = h5file['model_weights/{}'.format(layer_name)][found_data][()]
+                else:
+                    data = None
+                    
+            else:       
+                found_data = h5file[layer_name].visit(h5_visitor_func)
+                if found_data:
+                    data = h5file[layer_name][found_data][()]
+                else:
+                    data = None
 
         return data
 
-def get_weights_shape(h5filename, layer_name, var_name='kernel'):
+def get_weights_shape(h5filename, layer_name, var_name='kernel'): 
     def h5_visitor_func(name):
         if var_name in name:
             return name
 
     with h5py.File(h5filename, 'r') as h5file:
-        found_data = h5file[layer_name].visit(h5_visitor_func)
-        if found_data:
-            shape = h5file[layer_name][found_data].shape
+        
+        #If the h5 file is the whole model saved with model.save()
+        if 'model_weights' in list(h5file.keys()):
+            found_data = h5file['model_weights/{}'.format(layer_name)].visit(h5_visitor_func)
+            if found_data:
+                shape = h5file['model_weights/{}/{}'.format(layer_name, found_data)].shape
+            
+        #If not then treat it with regular h5 weights file
+        else:
+            found_data = h5file[layer_name].visit(h5_visitor_func)
+            if found_data:
+                shape = h5file['/{}/{}'.format(layer_name,found_data)].shape
 
     return shape
 


### PR DESCRIPTION
Hi, 

I added support for full model's `h5` file obtained from `model.save()`. 

I added in `if else` statements so when a json file is not supplied, it will be interpreted that the full model is saved in `KerasH5`. Thus, model architecture and weights will be processed differently. 

In particular, the only things that change are functions `get_weights_shape`, `get_weights_data`, and process of creating variable `model_arch`. 

Regarding the configuration file, if the user want to use their `h5` file from `model.save()`, they can just leave `KerasJson` blank and just supply the path to `KerasH5`. 

I tested  the with the `h5` file I created from model.save(), which I just uploaded [here](https://github.com/hls-fpga-machine-learning/models/tree/master/keras/KERAS_1layer). The code works file with both kinds of inputs (`json` and full `h5`)