### PR TITLE
Model profiling

### DIFF
--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -1,5 +1,5 @@
 import importlib
-libs = [('numpy', 'np'), ('pandas', 'pandas'), ('keras', 'keras'),
+libs = [('numpy', 'np'), ('pandas', 'pandas'), ('tensorflow', 'tensorflow'),
         ('seaborn', 'sb'), ('matplotlib.pyplot', 'plt')]
 for (name, short) in libs:
     try:
@@ -11,36 +11,86 @@ for (name, short) in libs:
         print(exception)
     else:
         globals()[short] = lib
+globals()['keras'] = tensorflow.keras
 
 def violinplot(data):
-    vp = sb.violinplot(x='x', y='weight', hue='layer', data=data)
+    f = plt.figure()
+    hue = 'layer' if 'layer' in data.keys() else None
+    vp = sb.violinplot(x='x', y='weight', hue=hue, data=data[data['x'] > 0])
     vp.set_yticklabels(vp.get_yticklabels(), rotation=45, ha='right')
-    vp.get_legend().remove()
+    if hue is not None:
+        vp.get_legend().remove()
     vp.set_xscale('log', basex=2)
-    plt.title('Distribution of weights')
-    plt.tight_layout()
-    return vp
+    return f
 
 def boxplot(data):
-    vp = sb.boxplot(x='x', y='weight', hue='layer', data=data, showfliers=False)
+    f = plt.figure()
+    hue = 'layer' if 'layer' in data.keys() else None
+    vp = sb.boxplot(x='x', y='weight', hue=hue, data=data[data['x'] > 0], showfliers=False)
     vp.set_yticklabels(vp.get_yticklabels(), rotation=45, ha='right')
-    vp.get_legend().remove()
+    if hue is not None:
+        vp.get_legend().remove()
     vp.set_xscale('log', basex=2)
-    plt.title('Distribution of weights')
-    plt.tight_layout()
-    return vp
+    return f
+
+def histogram(data):
+    from cycler import cycler
+    from matplotlib.ticker import MaxNLocator
+    # Power of 2 bins covering data range
+    high = np.ceil(np.log2(max(data['x']))) + 1
+    low = np.floor(np.log2(min(data[data['x'] > 0]['x']))) - 1
+    bits = np.arange(low, high, 1)
+    bins = 2 ** bits
+    f = plt.figure()
+    colors = sb.color_palette("husl", len(data['weight'].unique()))
+    for i, weight in enumerate(data['weight'].unique()):
+        x = data[data['weight'] == weight]['x']
+        h, b = np.histogram(x, bins=bins)
+        h = h * 1. / float(sum(h)) # normalize
+        plt.bar(bits[:-1], h, width=1, fill=False, label=weight, edgecolor=colors[i])
+    plt.gca().xaxis.set_major_locator(MaxNLocator(integer=True))
+    plt.xlabel('log2(x)')
+    plt.ylabel('frequency')
+    plt.legend()
+    return f
 
 def FacetGrid(data):
-    vp = sb.FacetGrid(data, row='weight', hue='layer')
+    hue = 'layer' if 'layer' in data.keys() else None
+    vp = sb.FacetGrid(data[data['x'] > 0], row='weight', hue=hue)
     vp.map(sb.kdeplot, "x", clip_on=False, shade=True, alpha=1, lw=1.5, bw=.2)
     vp.map(sb.kdeplot, "x", clip_on=False, color="w", lw=2, bw=.2)
     vp.map(plt.axhline, y=0, lw=2, clip_on=False)
     vp.fig.subplots_adjust(hspace=-.25)
-    return vp
+    return vp.fig
+
+plots = {'violinplot' : violinplot,
+         'boxplot' : boxplot,
+         'FacetGrid' : FacetGrid,
+         'histogram' : histogram}
 
 def numerical(model, X=None, plot='boxplot'):
-    data = {'x' : [], 'layer' : [], 'weight' : []}
+    """
+    Perform numerical profiling of a model
+
+    Parameters
+    ----------
+    model : keras model
+        The keras model to profile
+    X : array-like, optional
+        Test data on which to evaluate the model to profile activations
+        Must be formatted suitably for the model.predict(X) method
+    plot : str, optional
+        The type of plot to produce.
+        Options are: 'boxplot' (default), 'violinplot', 'histogram', 'FacetGrid'
+
+    Returns
+    -------
+    tuple
+        The pair of produced figures. First weights and biases, then activations
+    """
+
     print("Profiling weights")
+    data = {'x' : [], 'layer' : [], 'weight' : []}
     for layer in model.layers:
         name = layer.name
         weights = layer.get_weights()
@@ -49,22 +99,18 @@ def numerical(model, X=None, plot='boxplot'):
             n = len(w)
             data['x'].extend(abs(w).tolist())
             data['layer'].extend([name for j in range(n)])
-            #data['weight'].extend([i for j in range(len(w))])
             data['weight'].extend(['{}/{}'.format(name, i) for j in range(n)])
 
     data = pandas.DataFrame(data)
-
-    plots = {'violinplot' : violinplot,
-             'boxplot' : boxplot,
-             'FacetGrid' : FacetGrid}
-
     wp = plots[plot](data) # weight plot
+    plt.title("Distribution of (non-zero) weights")
+    plt.tight_layout()
 
     ap = None
     if X is not None:
         print("Profiling activations")
         # test layer by layer on data
-        data = {'x' : [], 'layer' : []}
+        data = {'x' : [], 'weight' : []}
         partial_model = keras.models.Sequential()
         for layer in model.layers:
             print("   {}".format(layer.name))
@@ -73,14 +119,11 @@ def numerical(model, X=None, plot='boxplot'):
             if not isinstance(layer, keras.layers.InputLayer):
                 y = partial_model.predict(X).flatten()
                 data['x'].extend(abs(y).tolist())
-                data['layer'].extend([layer.name for i in range(len(y))])
+                data['weight'].extend([layer.name for i in range(len(y))])
 
-        plt.figure()
         data = pandas.DataFrame(data)
-        ap = sb.violinplot(x='x', y='layer', data=data)
-        ap.set_yticklabels(ap.get_yticklabels(), rotation=45, ha='right')
-        ap.set_xscale('log', basex=2)
-        plt.title('Distribution of activations')
-
+        ap = plots[plot](data) # activation plot
+        plt.title("Distribution of (non-zero) activations")
+        plt.tight_layout()
     return wp, ap
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas
+import keras
+import seaborn as sb
+import matplotlib.pyplot as plt
+
+def violinplot(data):
+    vp = sb.violinplot(x='weight', y='x', hue='layer', data=data)
+    vp.set_xticklabels(vp.get_xticklabels(), rotation=45)
+    vp.get_legend().remove()
+    vp.set_yscale('log', basey=2)
+    return vp
+
+def boxplot(data):
+    vp = sb.boxplot(x='weight', y='x', hue='layer', data=data)
+    vp.set_xticklabels(vp.get_xticklabels(), rotation=45)
+    vp.get_legend().remove()
+    vp.set_yscale('log', basey=2)
+    return vp
+
+def FacetGrid(data):
+    vp = sb.FacetGrid(data, row='weight', hue='layer')
+    vp.map(sb.kdeplot, "x", clip_on=False, shade=True, alpha=1, lw=1.5, bw=.2)
+    vp.map(sb.kdeplot, "x", clip_on=False, color="w", lw=2, bw=.2)
+    vp.map(plt.axhline, y=0, lw=2, clip_on=False)
+    vp.fig.subplots_adjust(hspace=-.25)
+    return vp
+
+def numerical(model, X=None, plot='violinplot'):
+    data = {'x' : [], 'layer' : [], 'weight' : []}
+    print("Profiling weights")
+    for layer in model.layers:
+        name = layer.name
+        weights = layer.get_weights()
+        for i, w in enumerate(weights):
+            w = w.flatten()
+            n = len(w)
+            data['x'].extend(w.tolist())
+            data['layer'].extend([name for j in range(n)])
+            #data['weight'].extend([i for j in range(len(w))])
+            data['weight'].extend(['{}/{}'.format(name, i) for j in range(n)])
+
+    data = pandas.DataFrame(data)
+
+    plots = {'violinplot' : violinplot,
+             'boxplot' : boxplot,
+             'FacetGrid' : FacetGrid}
+
+    vp = plots[plot](data)
+
+    act_plot = None
+    if X is not None:
+        print("Profiling activations")
+        # test layer by layer on data
+        data = {'x' : [], 'layer' : []}
+        partial_model = keras.models.Sequential()
+        for layer in model.layers:
+            print("   {}".format(layer.name))
+            partial_model.add(layer)
+            partial_model.compile(optimizer='adam', loss='mse')
+            if not isinstance(layer, keras.layers.InputLayer):
+                y = partial_model.predict(X).flatten()
+                data['x'].extend(y.tolist())
+                data['layer'].extend([layer.name for i in range(len(y))])
+
+        plt.figure()
+        data = pandas.DataFrame(data)
+        act_plot = sb.violinplot(x='layer', y='x', data=data)
+        act_plot.set_xticklabels(act_plot.get_xticklabels(), rotation=45)
+        act_plot.set_yscale('log', basey=2)
+
+    return vp, act_plot
+

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -1,8 +1,16 @@
-import numpy as np
-import pandas
-import keras
-import seaborn as sb
-import matplotlib.pyplot as plt
+import importlib
+libs = [('numpy', 'np'), ('pandas', 'pandas'), ('keras', 'keras'),
+        ('seaborn', 'sb'), ('matplotlib.pyplot', 'plt')]
+for (name, short) in libs:
+    try:
+        lib = importlib.import_module(name)
+    except ImportError as error:
+        print(error)
+        print('Install hls4ml[profiling] extra depencies.')
+    except Exception as exception:
+        print(exception)
+    else:
+        globals()[short] = lib
 
 def violinplot(data):
     vp = sb.violinplot(x='x', y='weight', hue='layer', data=data)

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -5,17 +5,21 @@ import seaborn as sb
 import matplotlib.pyplot as plt
 
 def violinplot(data):
-    vp = sb.violinplot(x='weight', y='x', hue='layer', data=data)
-    vp.set_xticklabels(vp.get_xticklabels(), rotation=45)
+    vp = sb.violinplot(x='x', y='weight', hue='layer', data=data)
+    vp.set_yticklabels(vp.get_yticklabels(), rotation=45, ha='right')
     vp.get_legend().remove()
-    vp.set_yscale('log', basey=2)
+    vp.set_xscale('log', basex=2)
+    plt.title('Distribution of weights')
+    plt.tight_layout()
     return vp
 
 def boxplot(data):
-    vp = sb.boxplot(x='weight', y='x', hue='layer', data=data)
-    vp.set_xticklabels(vp.get_xticklabels(), rotation=45)
+    vp = sb.boxplot(x='x', y='weight', hue='layer', data=data, showfliers=False)
+    vp.set_yticklabels(vp.get_yticklabels(), rotation=45, ha='right')
     vp.get_legend().remove()
-    vp.set_yscale('log', basey=2)
+    vp.set_xscale('log', basex=2)
+    plt.title('Distribution of weights')
+    plt.tight_layout()
     return vp
 
 def FacetGrid(data):
@@ -26,7 +30,7 @@ def FacetGrid(data):
     vp.fig.subplots_adjust(hspace=-.25)
     return vp
 
-def numerical(model, X=None, plot='violinplot'):
+def numerical(model, X=None, plot='boxplot'):
     data = {'x' : [], 'layer' : [], 'weight' : []}
     print("Profiling weights")
     for layer in model.layers:
@@ -35,7 +39,7 @@ def numerical(model, X=None, plot='violinplot'):
         for i, w in enumerate(weights):
             w = w.flatten()
             n = len(w)
-            data['x'].extend(w.tolist())
+            data['x'].extend(abs(w).tolist())
             data['layer'].extend([name for j in range(n)])
             #data['weight'].extend([i for j in range(len(w))])
             data['weight'].extend(['{}/{}'.format(name, i) for j in range(n)])
@@ -46,9 +50,9 @@ def numerical(model, X=None, plot='violinplot'):
              'boxplot' : boxplot,
              'FacetGrid' : FacetGrid}
 
-    vp = plots[plot](data)
+    wp = plots[plot](data) # weight plot
 
-    act_plot = None
+    ap = None
     if X is not None:
         print("Profiling activations")
         # test layer by layer on data
@@ -60,14 +64,15 @@ def numerical(model, X=None, plot='violinplot'):
             partial_model.compile(optimizer='adam', loss='mse')
             if not isinstance(layer, keras.layers.InputLayer):
                 y = partial_model.predict(X).flatten()
-                data['x'].extend(y.tolist())
+                data['x'].extend(abs(y).tolist())
                 data['layer'].extend([layer.name for i in range(len(y))])
 
         plt.figure()
         data = pandas.DataFrame(data)
-        act_plot = sb.violinplot(x='layer', y='x', data=data)
-        act_plot.set_xticklabels(act_plot.get_xticklabels(), rotation=45)
-        act_plot.set_yscale('log', basey=2)
+        ap = sb.violinplot(x='x', y='layer', data=data)
+        ap.set_yticklabels(ap.get_yticklabels(), rotation=45, ha='right')
+        ap.set_xscale('log', basex=2)
+        plt.title('Distribution of activations')
 
-    return vp, act_plot
+    return wp, ap
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,15 @@ setup(name='hls4ml',
                         'pyyaml',
                         'h5py',
                         'onnx>=1.4.0'],
+      extras_require={
+        'profiling': [
+            'pandas',
+            'seaborn',
+            'matplotlib',
+            'keras',
+            'tensorflow'
+        ]
+      },
       scripts=['scripts/hls4ml'],
       include_package_data=True,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='hls4ml',
             'pandas',
             'seaborn',
             'matplotlib',
-            'keras',
             'tensorflow'
         ]
       },


### PR DESCRIPTION
Add utilities for numerical profiling of (`keras`) models.
Produces plots of the distributions of weights of all layer of a model, and optionally activations if provided test data.
Could be used to assist choice of precision.
Introduces a bunch of new imports: pandas, keras, seaborn...

API is like:
```
model = ... # load a model
X = ... # load some data
from hls4ml.model.profiling import numeric
numeric(model, X)
```

e.g. for the Keras 3 layer model with BatchNormalization:
![profiling_weights](https://user-images.githubusercontent.com/14807534/73025934-cef90500-3e30-11ea-83f2-6fa75e08632c.png)

And activations when provided with some of the jet tagging dataset:
![profiling_activation](https://user-images.githubusercontent.com/14807534/73025977-e1733e80-3e30-11ea-88fe-35418295f408.png)

