### PR TITLE
Support for comparing layer-by-layer output

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -409,6 +409,9 @@ class HLSModel(object):
 
         os.chdir(curr_dir)
 
+        #Convert to numpy array
+        output = np.array(output)
+
         if n_samples == 1:
             return output[0]
         else:
@@ -468,14 +471,23 @@ class HLSModel(object):
                 np_array = np.ctypeslib.as_array(layer_data, shape=layer_sizes[layer_name])
                 trace_output[layer_name].append(np.copy(np_array))
 
+        #Convert each layer's ouput data to arrays
+        trace_output_array = {}
+
+        for key in trace_output.keys():
+            trace_output_array[key] = np.array(trace_output[key])
+
+        #Convert to numpy array
+        output = np.array(output)
+
         free_func()
 
         os.chdir(curr_dir)
 
         if n_samples == 1:
-            return output[0], trace_output
+            return output[0], trace_output_array
         else:
-            return output, trace_output
+            return output, trace_output_array
 
     def build(self, reset=False, csim=True, synth=True, cosim=False, validation=False, export=False, vsynth=False):
         if 'linux' in sys.platform:

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -471,11 +471,8 @@ class HLSModel(object):
                 np_array = np.ctypeslib.as_array(layer_data, shape=layer_sizes[layer_name])
                 trace_output[layer_name].append(np.copy(np_array))
 
-        #Convert each layer's ouput data to arrays
-        trace_output_array = {}
-
         for key in trace_output.keys():
-            trace_output_array[key] = np.array(trace_output[key])
+            trace_output[key] = np.array(trace_output[key])
 
         #Convert to numpy array
         output = np.array(output)
@@ -485,9 +482,9 @@ class HLSModel(object):
         os.chdir(curr_dir)
 
         if n_samples == 1:
-            return output[0], trace_output_array
+            return output[0], trace_output
         else:
-            return output, trace_output_array
+            return output, trace_output
 
     def build(self, reset=False, csim=True, synth=True, cosim=False, validation=False, export=False, vsynth=False):
         if 'linux' in sys.platform:

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import six
 import os
 import sys
+import platform
 import ctypes
 import re
 import numpy as np
@@ -351,7 +352,12 @@ class HLSModel(object):
         os.system('cd {dir} && sh build_lib.sh'.format(dir=self.config.get_output_dir()))
         lib_name = '{}/firmware/{}.so'.format(self.config.get_output_dir(), self.config.get_project_name())
         if self._top_function_lib is not None:
-            dlclose_func = ctypes.CDLL('libdl.so').dlclose
+            
+            if platform.system() == "Linux":
+                dlclose_func = ctypes.CDLL('libdl.so').dlclose
+            elif platform.system() == "Darwin":
+                dlclose_func = ctypes.CDLL('libc.dylib').dlclose
+
             dlclose_func.argtypes = [ctypes.c_void_p]
             dlclose_func.restype = ctypes.c_int
             dlclose_func(self._top_function_lib._handle)    
@@ -410,7 +416,7 @@ class HLSModel(object):
         os.chdir(curr_dir)
 
         #Convert to numpy array
-        output = np.array(output)
+        output = np.asarray(output)
 
         if n_samples == 1:
             return output[0]
@@ -472,10 +478,10 @@ class HLSModel(object):
                 trace_output[layer_name].append(np.copy(np_array))
 
         for key in trace_output.keys():
-            trace_output[key] = np.array(trace_output[key])
+            trace_output[key] = np.asarray(trace_output[key])
 
         #Convert to numpy array
-        output = np.array(output)
+        output = np.asarray(output)
 
         free_func()
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -462,7 +462,7 @@ def _dist_diff(ymodel, ysim):
 
 def compare(keras_model, hls_model, X, plot_type = "dist_diff"):
     """
-    Compare each layer's output in keras and hls model
+    Compare each layer's output in keras and hls model. Note that the hls_model should not be compiled before using this.
     Params:
     ------
     keras_model : original keras model

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -270,7 +270,6 @@ def _is_ignored_layer(layer):
 
 def _get_ymodel_keras(keras_model, X):
     
-    
     partial_model = keras.models.Sequential()
     ymodel = {}
     

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -375,13 +375,26 @@ def _norm_diff(ymodel, ysim):
 def _dist_diff(ymodel, ysim):
     """
     Calculate the normalized distribution of the differences of the elements
-    of the output vectors 
+    of the output vectors. 
+    If difference >= original value then the normalized difference will be set to 1,
+    meaning "very difference".
+    If difference < original value then the normalized difference would be difference/original.
     """
 
     diff = {}
 
     for key in list(ymodel.keys()):
-        diff[key] = np.absolute(ymodel[key] - ysim[key]) / np.linalg.norm(ymodel[key]-ysim[key])
+        diff_vector = np.absolute(ymodel[key] - ysim[key])
+        abs_ymodel = np.absolute(ymodel[key])
+    
+        normalized_diff = np.zeros(diff_vector.shape)
+        normalized_diff[diff_vector >= abs_ymodel] = 1
+        
+        #Fill out the rest
+        index = diff_vector < abs_ymodel
+        normalized_diff[index] = diff_vector[index] / abs_ymodel[index]
+        
+        diff[key] = normalized_diff
     
     #---Box Plot---
     f, ax = plt.subplots()
@@ -391,7 +404,7 @@ def _dist_diff(ymodel, ysim):
     #--formatting
     plt.title("Layer-by-layer distribution of output differences")
     ax.set_xticklabels(list(diff.keys()))
-    ax.set_ylabel('Normalized difference')
+    ax.set_ylabel('Percent difference.')
     plt.xticks(rotation=90)
     plt.tight_layout()
 

--- a/hls4ml/templates/vivado/build_lib.sh
+++ b/hls4ml/templates/vivado/build_lib.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 CC=g++
-CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    CFLAGS="-O3 -fPIC -std=c++11 -fno-gnu-unique"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    CFLAGS="-O3 -fPIC -std=c++11"
+fi
 LDFLAGS=
-INCFLAGS="-Ifirmware/ap_types/"
+INCFLAGS="-I firmware/ap_types/"
 PROJECT=myproject
 
 ${CC} ${CFLAGS} ${INCFLAGS} -c firmware/${PROJECT}.cpp -o ${PROJECT}.o

--- a/hls4ml/templates/vivado/build_lib.sh
+++ b/hls4ml/templates/vivado/build_lib.sh
@@ -7,7 +7,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     CFLAGS="-O3 -fPIC -std=c++11"
 fi
 LDFLAGS=
-INCFLAGS="-I firmware/ap_types/"
+INCFLAGS="-Ifirmware/ap_types/"
 PROJECT=myproject
 
 ${CC} ${CFLAGS} ${INCFLAGS} -c firmware/${PROJECT}.cpp -o ${PROJECT}.o

--- a/hls4ml/templates/vivado/firmware/parameters.h
+++ b/hls4ml/templates/vivado/firmware/parameters.h
@@ -1,9 +1,9 @@
 #ifndef PARAMETERS_H_
 #define PARAMETERS_H_
 
-#include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
+
 #include "nnet_utils/nnet_dense.h"
 #include "nnet_utils/nnet_dense_large.h"
 #include "nnet_utils/nnet_dense_compressed.h"


### PR DESCRIPTION
This is just some preliminary codes for comparing layer-by-layer output. Current implementation requires the user to convert the config file in debug mode, and then use the compare function to produce the plot depicting the differences of each layer. The printing code has been absorbed by Vladimir earlier so it won't appear in this PR. 

I still have some points to discuss, since this is far from optimal:

1. The user currently still has to convert the config in debug mode first and then use `compare`, do we want to automatically run convert in debug mode when the user pass the config to `compare`, and then automatically read the printed out outputs? 

2. Currently, I'm just calculating the distance between two output's vectors by using `np.linalg.norm`, but I'm sure there is a better way ... 