### PR TITLE
Bash not sh

### DIFF
--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -337,7 +337,7 @@ class HLSModel(object):
 
     def compile(self):
         self.write()
-        os.system('cd {dir} && sh build_lib.sh'.format(dir=self.config.get_output_dir()))
+        os.system('cd {dir} && bash build_lib.sh'.format(dir=self.config.get_output_dir()))
         lib_name = '{}/firmware/{}.so'.format(self.config.get_output_dir(), self.config.get_project_name())
         if self._top_function_lib is not None:
             


### PR DESCRIPTION
With `sh build_lib.sh` in `HLSModel.compile()` I got the error:
```
Writing HLS project
Done
build_lib.sh: 4: build_lib.sh: [[: not found
build_lib.sh: 6: build_lib.sh: [[: not found
```
Changing to: `bash build_lib.sh` it works.
`[[` is a bash-builtin right, but not in `sh`?