### PR TITLE
QKeras precision inference fix

### DIFF
--- a/hls4ml/converters/keras/qkeras.py
+++ b/hls4ml/converters/keras/qkeras.py
@@ -26,7 +26,7 @@ class QKerasQuantizer(Quantizer):
 def get_type(quantizer_config):
     width = quantizer_config['config']['bits']
     integer = quantizer_config['config'].get('integer', 0)
-    if integer == 0:
+    if width == integer:
         if width == 1:
             return IntegerPrecisionType(width=1, signed=False)
         else:

--- a/hls4ml/model/hls_model.py
+++ b/hls4ml/model/hls_model.py
@@ -337,7 +337,7 @@ class HLSModel(object):
 
     def compile(self):
         self.write()
-        os.system('cd {dir} && sh build_lib.sh'.format(dir=self.config.get_output_dir()))
+        os.system('cd {dir} && bash build_lib.sh'.format(dir=self.config.get_output_dir()))
         lib_name = '{}/firmware/{}.so'.format(self.config.get_output_dir(), self.config.get_project_name())
         if self._top_function_lib is not None:
             


### PR DESCRIPTION
I think the check to return integer type was wrong.
Before, `quantized_bits(8,0,0)` (8 bits, 0 integer bits) was interpreted as `ap_int<8>`.
Now it is interpreted as `ap_fixed<8,0>` as it should be.