### PR TITLE
Add missing BatchNormalization include for ApplyAlpha layer

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -79,7 +79,7 @@ class ApplyAlpha(BatchNormalization):
 register_layer('ApplyAlpha', ApplyAlpha)
 # TODO ideally: for backend in backends
 temps = templates.get_backend('Vivado')
-temps.register_templates('ApplyAlpha', temps.get_function_template('BatchNormalization'), temps.get_config_template('BatchNormalization'))
+temps.register_templates('ApplyAlpha', temps.get_function_template('BatchNormalization'), temps.get_config_template('BatchNormalization'), temps.get_include_list('BatchNormalization'))
 
 class QKerasFactorizeAlpha(OptimizerPass):
     '''OptimizerPass for extracting alpha "scale" from QKeras quantized layer.

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -223,7 +223,6 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
     bool initialized = false;
     typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
     typename CONFIG_T::inv_table_t invert_table[CONFIG_T::table_size];
-	#pragma HLS resource variable=exp_table core=ROM_nP_BRAM
 #else
     static bool initialized = false;
     static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
@@ -231,10 +230,10 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
 
 #endif
     if (!initialized) {
-		// Note we are exponentiating the inputs, which have type data_T
-		init_exp_table<data_T, CONFIG_T>(exp_table);
-		// Note we are inverting the exponentials, which have type exp_table_t
-		init_invert_table<typename CONFIG_T::exp_table_t, CONFIG_T>(invert_table);
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<data_T, CONFIG_T>(exp_table);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::exp_table_t, CONFIG_T>(invert_table);
         initialized = true;
     }
 

--- a/hls4ml/templates/vivado/nnet_utils/nnet_common.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_common.h
@@ -50,6 +50,77 @@ typedef ap_fixed<32,10> accum_t_def;
    }
  }
 
+ /* ---
+  * Balanced tree reduce implementation.
+  * For use in scenarios where Vivado cannot expression balance
+  * Reduces an array of inputs to a single value using the template binary operator 'Op',
+  * for example summing all elements with Op_add, or finding the maximum with Op_max
+  * Use only when the input array is fully unrolled. Or, slice out a fully unrolled section
+  * before applying and accumulate the result over the rolled dimension.
+  * --- */
+ template<class T, int N, class Op>
+ T reduce(T* x, Op op){
+	static constexpr int leftN = pow2(floorlog2(N - 1)) > 0 ? pow2(floorlog2(N - 1)) : 0;
+	static constexpr int rightN = N - leftN > 0 ? N - leftN : 0;
+	if(N == 1){
+		return x[0];
+	}else if(N == 2){
+		return op(x[0],x[1]);
+	}else{
+		T left[leftN];
+		T right[rightN];
+		#pragma HLS array_partition variable=left complete
+		#pragma HLS array_partition variable=right complete
+		for(int i = 0; i < leftN; i++){
+			left[i] = x[i];
+		}
+		for(int i = 0; i < rightN; i++){
+			right[i] = x[i+leftN];
+		}
+		return op(reduce<T,leftN,Op>(left, op), reduce<T,rightN,Op>(right, op));
+	}
+ }
+
+ template<class T>
+ class Op_add{
+ public:
+	 T operator()(T a, T b){
+		 return a + b;
+	 }
+ };
+
+ template<class T>
+ class Op_and{
+ public:
+	 T operator()(T a, T b){
+		 return a && b;
+	 }
+ };
+
+ template<class T>
+ class Op_or{
+ public:
+	 T operator()(T a, T b){
+		 return a || b;
+	 }
+ };
+
+ template<class T>
+ class Op_max{
+ public:
+     T operator()(T a, T b){
+        return a >= b ? a : b;
+     }
+ };
+
+ template<class T>
+ class Op_min{
+ public:
+     T operator()(T a, T b){
+        return a <= b ? a : b;
+     }
+ };
+
 }
 
 #endif

--- a/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_helpers.h
@@ -232,6 +232,10 @@ constexpr int ceillog2(int x){
   return (x <= 2) ? 1 : 1 + ceillog2((x+1) / 2);
 }
 
+constexpr int floorlog2(int x){
+  return (x < 2) ? 0 : 1 + floorlog2(x / 2);
+}
+
 constexpr int pow2(int x){
   return x == 0 ? 1 : 2 * pow2(x - 1);
 }


### PR DESCRIPTION
As it says: BatchNormalization includes weren't registered for ApplyAlpha layer, so a model using quantizer with `alpha`, and no BatchNormalization layers wouldn't compile.