### PR TITLE
Fix PointwiseConv1d/Dense + BatchNorm fusion

### DIFF
--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -1,6 +1,6 @@
 from hls4ml.model.optimizer import OptimizerPass
 from hls4ml.model.hls_model import Dense
-
+import numpy as np
 
 class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
     def match(self, node):
@@ -47,8 +47,9 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
 
         class_name = 'PointwiseConv' + str(dim) + 'D'
         pw_node = model.make_node(class_name, node.name, pointwise_attrs, node.inputs.copy())
-        for key in node.weights:
-            pw_node.weights[key] = node.weights[key]
+        if len(node.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
+            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0,1))
+        pw_node.weights['bias'].data = node.weights['bias'].data
         model.replace_node(node, pw_node)
         
         return True

--- a/hls4ml/model/optimizer/passes/multi_dense.py
+++ b/hls4ml/model/optimizer/passes/multi_dense.py
@@ -47,6 +47,8 @@ class ReplaceMultidimensionalDenseWithConv(OptimizerPass):
 
         class_name = 'PointwiseConv' + str(dim) + 'D'
         pw_node = model.make_node(class_name, node.name, pointwise_attrs, node.inputs.copy())
+        for key in node.weights:
+            pw_node.weights[key] = node.weights[key]
         model.replace_node(node, pw_node)
         
         return True

--- a/hls4ml/model/optimizer/passes/pointwise.py
+++ b/hls4ml/model/optimizer/passes/pointwise.py
@@ -51,8 +51,9 @@ class OptimizePointwiseConv(OptimizerPass):
     def transform(self, model, node):
         dim = node.__class__.__name__[-2:] # '1D' or '2D'
         pw_node = model.make_node('PointwiseConv' + dim, node.name, node.attributes.copy(), node.inputs.copy())
-        for key in node.weights:
-            pw_node.weights[key] = node.weights[key]
+        if len(node.weights['weight'].data.shape) == 2: # This can happen if we assign weights of Dense layer to 1x1 Conv2D
+            pw_node.weights['weight'].data = np.expand_dims(node.weights['weight'].data, axis=(0,1))
+        pw_node.weights['bias'].data = node.weights['bias'].data
         model.replace_node(node, pw_node)
         
         return True

--- a/hls4ml/model/optimizer/passes/pointwise.py
+++ b/hls4ml/model/optimizer/passes/pointwise.py
@@ -51,6 +51,8 @@ class OptimizePointwiseConv(OptimizerPass):
     def transform(self, model, node):
         dim = node.__class__.__name__[-2:] # '1D' or '2D'
         pw_node = model.make_node('PointwiseConv' + dim, node.name, node.attributes.copy(), node.inputs.copy())
+        for key in node.weights:
+            pw_node.weights[key] = node.weights[key]
         model.replace_node(node, pw_node)
         
         return True


### PR DESCRIPTION
- fix PointwiseConv/Dense + BatchNorm fusion

I'm not sure if this is the best way to do it, but I figured we can discuss. Without this change, the weights/biases are not correct for the new `pw_node` instance.