### PR TITLE
propagate reuse factor for Quartus, allow rf=1

### DIFF
--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -131,19 +131,20 @@ class FPGABackend(Backend):
 
             layer.set_attr('reuse_factor', float(rf) / kernel_multiplies)
 
-
-    def convert_precision_string(self, precision):
+    @staticmethod
+    def convert_precision_string(precision):
         if isinstance(precision, IntegerPrecisionType) or isinstance(precision, FixedPrecisionType):
             return precision
 
         if precision.startswith('ap_'):
-            return self._convert_ap_type(precision)
+            return FPGABackend._convert_ap_type(precision)
         elif precision.startswith('ac_'):
-            return self._convert_ac_type(precision)
+            return FPGABackend._convert_ac_type(precision)
         else:
             raise Exception('Cannot convert precision string: {}'.format(precision))
 
-    def _convert_ap_type(self, precision):
+    @staticmethod
+    def _convert_ap_type(precision):
         '''
         Convert a precision string (e.g. "ap_fixed<16,6>" to the internal FixedPrecisionTypes etc)
         '''
@@ -162,9 +163,9 @@ class FPGABackend(Backend):
             fields = 1
             signed = bool(~('u' in precision))
         if len(bits) > fields:
-            sat_mode = bits[fields]
+            round_mode = bits[fields]
         if len(bits) > fields+1:
-            round_mode = bits[fields+1]
+            sat_mode = bits[fields+1]
         if len(bits) > fields+2:
             sat_bits = int(bits[fields+2])
         if 'fixed' in precision:
@@ -172,7 +173,8 @@ class FPGABackend(Backend):
         elif 'int' in precision:
             return IntegerPrecisionType(W, signed)
 
-    def _convert_ac_type(self, precision):
+    @staticmethod
+    def _convert_ac_type(precision):
         '''
         Convert a precision string (e.g. "ac_fixed<16,6>" to the internal FixedPrecisionTypes etc)
         '''
@@ -195,9 +197,9 @@ class FPGABackend(Backend):
                 signed = bool(bits[1])
                 fields = 2
         if len(bits) > fields:
-            sat_mode = bits[fields]
+            round_mode = bits[fields]
         if len(bits) > fields+1:
-            round_mode = bits[fields+1]
+            sat_mode = bits[fields+1]
         if 'fixed' in precision:
             return FixedPrecisionType(W, I, signed, round_mode, sat_mode)
         elif 'int' in precision:

--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -43,7 +43,7 @@ class FPGABackend(Backend):
         
         return lib_name
 
-    def get_valid_reuse_factors(self, layer):
+    def get_valid_reuse_factors(self, layer, allow_one=False):
         n_in = 0
         n_out = 0
         if 'Dense' in layer.class_name:
@@ -63,7 +63,7 @@ class FPGABackend(Backend):
             if _assert:
                 valid_reuse_factors.append(rf)
         # Avoid using RF=1
-        if valid_reuse_factors[0] == 1:
+        if valid_reuse_factors[0] == 1 and not allow_one:
             valid_reuse_factors.pop(0)
         return valid_reuse_factors
 
@@ -99,8 +99,8 @@ class FPGABackend(Backend):
         else:
             return before
 
-    def set_closest_reuse_factor(self, layer):
-        valid_rf = self.get_valid_reuse_factors(layer)
+    def set_closest_reuse_factor(self, layer, allow_one=False):
+        valid_rf = self.get_valid_reuse_factors(layer, allow_one)
         chosen_rf = layer.get_attr('reuse_factor')
         if chosen_rf not in valid_rf:
             closest_rf = self.get_closest_reuse_factor(valid_rf, chosen_rf)

--- a/hls4ml/backends/quartus/quartus_backend.py
+++ b/hls4ml/backends/quartus/quartus_backend.py
@@ -86,8 +86,8 @@ class QuartusBackend(FPGABackend):
     def gen_quartus_weight_array(self, layer):
         rf = layer.get_attr('reuse_factor')
         block_factor = int((layer.attributes['n_in']*layer.attributes['n_out'])/rf)
-        bf_rounded = int(pow(2, np.ceil(np.log(block_factor)/np.log(2))))
-        rf_rounded = int(pow(2, np.ceil(np.log(rf)/np.log(2))))
+        bf_rounded = int(pow(2, np.ceil(np.log2(block_factor))))
+        rf_rounded = int(pow(2, np.ceil(np.log2(rf))))
 
         layer.weights['weight'].data = np.transpose(layer.weights['weight'].data).flatten()
 
@@ -171,6 +171,14 @@ class QuartusBackend(FPGABackend):
         else:
             return 'ac_int<{width}, {signed}>'.format(width=width, signed='false' if not signed else 'true')
 
+    @layer_optimizer(Layer)
+    def init_base_layer(self, layer):
+        reuse_factor = layer.model.config.get_reuse_factor(layer)
+        layer.set_attr('reuse_factor', reuse_factor)
+
+        target_cycles = layer.model.config.get_target_cycles(layer)
+        layer.set_attr('target_cycles', target_cycles)
+
     @layer_optimizer(Dense)
     def init_dense(self, layer):
         index_t = IntegerPrecisionType(width=1, signed=False)
@@ -181,7 +189,7 @@ class QuartusBackend(FPGABackend):
         if layer.model.config.get_compression(layer):
             layer.set_attr('strategy', 'compressed')
         else:
-            self.set_closest_reuse_factor(layer)
+            self.set_closest_reuse_factor(layer, allow_one=True)
             self.gen_quartus_weight_array(layer)
             layer.set_attr('strategy', 'resource')
 

--- a/hls4ml/model/profiling.py
+++ b/hls4ml/model/profiling.py
@@ -159,7 +159,7 @@ types_plots = {'boxplot' : types_boxplot,
 
 def ap_fixed_WIF(dtype):
     from hls4ml.backends import VivadoBackend
-    dtype = VivadoBackend.convert_precision_string(None, dtype) 
+    dtype = VivadoBackend.convert_precision_string(dtype)
     W, I, F = dtype.width, dtype.integer, dtype.fractional
     return W, I, F
 


### PR DESCRIPTION
The reuse factor propagation was broken for the Quartus backend. This pull request fixes the problem by adding a init_base_layer optimizer, copied directly from the Vivado backend, to the standard flow.

Because the Quartus backend doesn't have a separate "Latency" version of the Dense layer, currently a reuse factor of 1 is not considered valid. We don't have to make that restriction, however, I added a flag to get_valid_reuse_factors and set_closest_reuse_factor called allow_one, default False, which controls whether 1 is a a valid reuse factor. For Quartus, this PR calls the functions with allow_one = True.
