### PR TITLE
propagate reuse factor for Quartus, allow rf=1 for Resouce in all cases

### DIFF
--- a/hls4ml/backends/fpga/fpga_backend.py
+++ b/hls4ml/backends/fpga/fpga_backend.py
@@ -62,9 +62,6 @@ class FPGABackend(Backend):
             _assert = self._check_conditions(n_in, n_out, rf)
             if _assert:
                 valid_reuse_factors.append(rf)
-        # Avoid using RF=1
-        if valid_reuse_factors[0] == 1:
-            valid_reuse_factors.pop(0)
         return valid_reuse_factors
 
     def _check_conditions(self, n_in, n_out, rf):


### PR DESCRIPTION
This is a replacement of #45; fix rf propagation in the quartus branch, and allows rf=1 in all cases.