### PR TITLE
Add quartus extras requirements, and install in tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ pytest:
     - git submodule init
     - git submodule update
     - conda activate hls4ml-testing
-    - pip install .[profiling]
+    - pip install .[profiling,quartus]
   script:
     - cd test/pytest
     - pytest -rA --cov-report xml --cov-report term --cov=hls4ml --junitxml=report.xml

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ setup(name='hls4ml',
             'pandas',
             'seaborn',
             'matplotlib'
+        ],
+        'quartus': [
+            'calmjs.parse',
+            'tabulate'
         ]
       },
       scripts=['scripts/hls4ml'],


### PR DESCRIPTION
Does what it says: add a quartus extras for backend dependencies, with calmjs.parse & tabulate