### PR TITLE
remove reduntant --backend parsing

### DIFF
--- a/scripts/hls4ml
+++ b/scripts/hls4ml
@@ -32,7 +32,6 @@ def main():
 
     config_parser.add_argument('-m', '--model', help='Model file to convert (Keras .h5 or .json file, ONNX .onnx file, or TensorFlow .pb file)', default=None)
     config_parser.add_argument('-w', '--weights', help='Optional weights file (if Keras .json file is provided))', default=None)
-    config_parser.add_argument('-b', '--backend', help='Backend to use (Vivado, Quartus, Catapult)', default='vivado')
     config_parser.add_argument('-p', '--project', help='Project name', default='myproject')
     config_parser.add_argument('-d', '--dir', help='Project output directory', default='my-hls-test')
     config_parser.add_argument('-f', '--fpga', help='FPGA part', default='xcku115-flvb2104-2-i')


### PR DESCRIPTION
--backend appeared twice in the argument parser, giving me an error. The PR removes one of the redundant options. (It would also be fine to remove the other.)