### PR TITLE
Add try catch to quartus report, clean up quartus build and makefile

### DIFF
--- a/hls4ml/report/quartus_report.py
+++ b/hls4ml/report/quartus_report.py
@@ -149,9 +149,12 @@ def _find_reports(rpt_dir):
             with open(filename) as dataFile:
                 verification_data = dataFile.read()
                 verification_data = read_js_object(verification_data)
-            results['num_invocation'] = verification_data['verifJSON']['functions'][0]['data'][0]
-            results['Latency'] = verification_data['verifJSON']['functions'][0]['data'][1].split(",")
-            results['ii'] = verification_data['verifJSON']['functions'][0]['data'][2].split(",")
+            try:
+                results['num_invocation'] = verification_data['verifJSON']['functions'][0]['data'][0]
+                results['Latency'] = verification_data['verifJSON']['functions'][0]['data'][1].split(",")
+                results['ii'] = verification_data['verifJSON']['functions'][0]['data'][2].split(",")
+            except KeyError:
+                print("Was not able to parse verification file. Please open <project>/reports/report.html for more information.")
         else:
             print('Verification file not found. Run ./[projectname]-fpga to generate.')
 

--- a/hls4ml/templates/quartus/Makefile
+++ b/hls4ml/templates/quartus/Makefile
@@ -2,7 +2,7 @@ DEVICE   := Arria10
 TARGETS  := myproject-fpga
 
 CXX          := i++
-CXXFLAGS     := $(USERCXXFLAGS) -Ifirmware/ap_types/ -march=$(DEVICE)#--quartus-compile
+CXXFLAGS     := $(USERCXXFLAGS) -march=$(DEVICE)#--quartus-compile
 RM           := rm -rf
 DEBUG_FLAGS  = --time $@_time.log -v
 SOURCE_FILES := myproject_test.cpp firmware/myproject.cpp

--- a/hls4ml/templates/quartus/build_lib.sh
+++ b/hls4ml/templates/quartus/build_lib.sh
@@ -7,7 +7,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     CFLAGS="-O3 -fPIC -std=c++11"
 fi
 LDFLAGS=
-INCFLAGS="-Ifirmware/ac_types/ -Ifirmware/ap_types/"
+INCFLAGS="-Ifirmware/ac_types/"
 PROJECT=myproject
 LIB_STAMP=mystamp
 


### PR DESCRIPTION
The Quartus report generation often fails, so this PR wraps it in a try-catch. The quartus report generation probably needs some rework in general, but this prevents the build step from failing.

Also I removed include search path inclusion of ap_types in Quartus, since those aren't used, and the directories actually do not exist in Quartus projects. 