### PR TITLE
allocate entry in array before use (quartus testbench)

### DIFF
--- a/hls4ml/writer/quartus_writer.py
+++ b/hls4ml/writer/quartus_writer.py
@@ -290,6 +290,8 @@ class QuartusWriter(Writer):
                 newline = line
                 newline += indent + 'for(int i = 0; i < num_iterations; i++) {\n'
                 for inp in model.get_input_variables():
+                    newline += indent + f'  inputs.emplace_back();\n'
+                    newline += indent + f'  outputs.emplace_back();\n'
                     newline += indent + f'  std::fill_n(inputs[i].{inp.member_name}, {inp.size_cpp()}, 0.0);\n'
                 newline += indent + '}\n'
 


### PR DESCRIPTION
The quartus testbench has a problem of writing unallocated memory if there are no testfiles. This fixes it.