### PR TITLE
update precision propagation for signed, select im2col in test

### DIFF
--- a/test/pytest/test_auto_precision.py
+++ b/test/pytest/test_auto_precision.py
@@ -150,6 +150,13 @@ def test_auto_precision_conv(keras_model_conv1d, keras_model_conv2d, data_2d, da
             },
         },
     }
+
+    # Winograd is not bit-accurate, so avoid it.
+    if backend == 'Quartus' and io_type == 'io_parallel':
+        config["LayerName"]["first_layer"]["Implementation"] = "im2col"
+        config["LayerName"]["middle_layer"]["Implementation"] = "im2col"
+        config["LayerName"]["last_layer"]["Implementation"] = "im2col"
+
     odir = str(test_root_path / f'hls4mlprj_auto_{model_type}_{backend}_{io_type}')
     hls_model = hls4ml.converters.convert_from_keras_model(
         model, hls_config=config, io_type=io_type, output_dir=odir, backend=backend


### PR DESCRIPTION
# Description

These are fixes to the auto_precision that I think are useful. These are the changes:

1.  Support signed and unsigned when inferring common precision
2. Fix n_ops for Dense
3. Force im2col when doing io_parallel conv in Quartus.

Please note how I removed lines 83-84 and 89-90 in infer_precison.py (+ similarly for bias) and replaced it by changing the else part to always be executed. I think this is correct, but please check. This is supposed to be just a coding change, not a logic change.

I put the option to not increase the precision for bias if the bias values are always 0. In my code previously (and in the QONNX pull request) this is on, but I turned it off by default in case we don't want to depend on the actual weight values (for example, if they are updatable). So really it's never used currently.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Same as before

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
